### PR TITLE
fix: exclude withdrawn/cancelled requests from duplicate check

### DIFF
--- a/api/src/appRequest/appRequest.service.ts
+++ b/api/src/appRequest/appRequest.service.ts
@@ -235,9 +235,10 @@ export class AppRequestService extends AuthService<AppRequest> {
     if (!this.mayCreate() && user.login === this.login) return { message: 'You may not create a request.' }
     if (!this.mayCreateOther() && user.login !== this.login) return { message: 'You may not create requests for other people.' }
     if (!appConfig.multipleRequestsPerPeriod) {
+      const activeStatuses = Object.values(AppRequestStatus).filter(s => s !== AppRequestStatus.WITHDRAWN && s !== AppRequestStatus.CANCELLED)
       const requests = 'internalId' in user
-        ? await this.svc(AppRequestServiceInternal).find({ periodIds: [period.id], userInternalIds: [user.internalId] })
-        : await this.svc(AppRequestServiceInternal).find({ periodIds: [period.id], logins: [user.login] })
+        ? await this.svc(AppRequestServiceInternal).find({ periodIds: [period.id], userInternalIds: [user.internalId], status: activeStatuses })
+        : await this.svc(AppRequestServiceInternal).find({ periodIds: [period.id], logins: [user.login], status: activeStatuses })
       if (requests.length > 0) return { message: `A request already exists in ${period.name}.`, arg: 'login' }
     }
     return undefined


### PR DESCRIPTION
## Summary
- When `multipleRequestsPerPeriod` is `false`, the duplicate request guard in `reasonMayNotCreateInPeriodForUser` was querying all requests for the user in the period — including withdrawn and cancelled ones
- This prevented users from submitting a new request after withdrawing a previous one
- Fix passes `status` filter to `find()` to exclude `WITHDRAWN` and `CANCELLED` at the query level

## Test plan
- [ ] Configure an app with `multipleRequestsPerPeriod: false`
- [ ] Submit a request, then withdraw it
- [ ] Verify a new request can be created in the same period
- [ ] Verify that a second *active* request is still blocked