### PR TITLE
Clear invalidated flag when prompt is re-saved with unchanged data

### DIFF
--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -294,6 +294,9 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
       }
       if (validateOnly) return
       response.success = true // if we got this far, it's saving the data, so that's a success even if the data isn't quite valid yet
+      // Always revalidate the current prompt on save — it may have been
+      // externally invalidated and re-saved with identical data (#165).
+      await setRequirementPromptsValid([prompt.key], db)
       if (!equal(appRequestData[prompt.key], processedData)) {
         updated = true
         previousAppRequestStatus = appRequest.status


### PR DESCRIPTION
## Summary
- When a prompt is externally invalidated (via `invalidUponChange`) and the user re-saves it without changing data, `equal()` returns true and `setRequirementPromptsValid` is never called — leaving the prompt permanently stuck as invalidated
- Adds a `setRequirementPromptsValid([prompt.key])` call before the `equal()` check so any successful save clears the invalidated flag

## Test plan
- [ ] Answer prompts A and B, where A has `invalidUponChange` targeting B
- [ ] Go back and change A's answer — B should become invalidated
- [ ] Navigate to B and click Continue without changing anything — B should no longer be invalidated and navigation should proceed

Ref: txstate-etc/va-certification#165