### PR TITLE
Update prompt prestage recurrence options

### DIFF
--- a/api/src/prompt/prompt.model.ts
+++ b/api/src/prompt/prompt.model.ts
@@ -1,6 +1,22 @@
 import { Field, ID, InputType, ObjectType, registerEnumType } from 'type-graphql'
 import { ApplicationPhase, AppRequestPhase, AppRequestStatusDB, PromptDefinition, promptRegistry, PromptRow, RequirementType } from '../internal.js'
 
+export enum PromptPreStagingRecurrence {
+  NEVER = 'NEVER',
+  ALWAYS = 'ALWAYS',
+  INVALID = 'INVALID'
+}
+
+registerEnumType(PromptPreStagingRecurrence, {
+  name: 'PromptPreStagingRecurrence',
+  description: 'Determines how often the prestage prompt operation recurs.',
+  valuesConfig: {
+    NEVER: { description: 'The prestage prompt operation never recurs, only runs on first load of prompt when no prompt data exists. This is the default.' },
+    ALWAYS: { description: 'The prestage prompt operation recurs every time the prompt is loaded.' },
+    INVALID: { description: 'The prestage prompt operation recurs every time the prompt is loaded and has previously been invalidated by another prompt.' }
+  }
+})
+
 export enum PromptVisibility {
   UNREACHABLE = 'UNREACHABLE',
   APPLICATION_DUPE = 'APPLICATION_DUPE',

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -10,7 +10,8 @@ import {
   AppRequestServiceInternal, AppRequestPhase, RequirementType, periodConfigCache, programRegistry,
   statusVisibleToApplicantPhases, applicantRequirementTypes, setRequirementPromptsValid,
   RQContext,
-  RequirementPromptFilter
+  RequirementPromptFilter,
+  PromptPreStagingRecurrence
 } from '../internal.js'
 
 const byInternalIdLoader = new PrimaryKeyLoader({
@@ -160,9 +161,11 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
 
   async requiresStaging (requirementPrompt: RequirementPrompt) {
     if (requirementPrompt.definition.prestage != null) {
-      const recur = ('recur' in requirementPrompt.definition.prestage) ? requirementPrompt.definition.prestage.recur : false
       const data = await this.svc(AppRequestServiceInternal).getData(requirementPrompt.appRequestInternalId)
-      return (recur || data[requirementPrompt.key] == null) ? true : false
+      const recur = ('recur' in requirementPrompt.definition.prestage) ? requirementPrompt.definition.prestage.recur : false
+      if (data[requirementPrompt.key] == null) return true // first occurence should always run no matter the recur setting, since there is no existing data
+      if (recur === true || recur === PromptPreStagingRecurrence.ALWAYS) return true
+      if (recur === PromptPreStagingRecurrence.INVALID && requirementPrompt.invalidated) return true
     }
     return false
   }

--- a/api/src/registry/prompt.ts
+++ b/api/src/registry/prompt.ts
@@ -5,7 +5,7 @@ import addFormats from 'ajv-formats'
 import addErrors from 'ajv-errors'
 import db from 'mysql2-async/db'
 import { Cache, isNotBlank, isNotEmpty, sortby } from 'txstate-utils'
-import { AppRequest, getIndexesInUse, Period, programRegistry, requirementRegistry, RQContext, TagDefinition, type AppRequestData } from '../internal.js'
+import { AppRequest, getIndexesInUse, Period, programRegistry, requirementRegistry, RQContext, TagDefinition, type AppRequestData, type PromptPreStagingRecurrence } from '../internal.js'
 import type { Queryable } from 'mysql2-async'
 
 export interface AppRequestMigration<DataType = Omit<AppRequestData, 'savedAtVersion'>> {
@@ -397,7 +397,7 @@ export interface PromptDefinition<DataType = any, InputDataType = DataType, Conf
    * If recur is false or not provided, the process function will only run on the first evaluation of the app request where there is no existing data for this prompt,
    */
   prestage?: ((appRequest: AppRequest, config: ConfigurationDataType, allPeriodConfig: Record<string, any>, ctx: RQContext, db: Queryable) => Promise<DataType> | DataType) | {
-    recur?: boolean
+    recur?: PromptPreStagingRecurrence | boolean
     process: (appRequest: AppRequest, config: ConfigurationDataType, allPeriodConfig: Record<string, any>, ctx: RQContext, db: Queryable) => Promise<DataType> | DataType
   }
   /**

--- a/demos/src/default/definitions/prompts/state.prompts.ts
+++ b/demos/src/default/definitions/prompts/state.prompts.ts
@@ -16,6 +16,7 @@ export const which_state_prompt: PromptDefinition = {
     } else if (data.stateName !== stateList.find(sl => sl.value === data.state)?.label) messages.push({ type: MutationMessageType.error, message: 'State abbreviation does not match state name.', arg: 'stateName' })
     return messages
   },
+  invalidUponChange: [{ promptKey: 'have_yard_prompt', reason: 'Need to test prestage with invalidated prompt' }],
   tags: [{
     category: 'state',
     categoryLabel: 'State',

--- a/demos/src/default/definitions/prompts/yard.prompts.ts
+++ b/demos/src/default/definitions/prompts/yard.prompts.ts
@@ -1,4 +1,4 @@
-import { type PromptDefinition } from '@reqquest/api'
+import { type PromptDefinition, PreStageingRecurrence } from '@reqquest/api'
 import { type MutationMessage, MutationMessageType } from '@txstate-mws/graphql-server'
 import { YardPromptData, YardPromptSchema } from '../models/index.js'
 
@@ -8,7 +8,7 @@ export const have_yard_prompt: PromptDefinition<YardPromptData, YardPromptData> 
   description: 'Applicants will enter information about their yard including how large it is and how many pets will share it.',
   schema: YardPromptSchema,
   prestage: {
-    recur: true,
+    recur: PreStageingRecurrence.INVALID,
     process: (appRequest, config, allPeriodConfig, ctx, db): YardPromptData => {
       return {
         haveYard: true,

--- a/demos/src/default/definitions/prompts/yard.prompts.ts
+++ b/demos/src/default/definitions/prompts/yard.prompts.ts
@@ -1,4 +1,4 @@
-import { type PromptDefinition, PreStageingRecurrence } from '@reqquest/api'
+import { type PromptDefinition, PromptPreStagingRecurrence } from '@reqquest/api'
 import { type MutationMessage, MutationMessageType } from '@txstate-mws/graphql-server'
 import { YardPromptData, YardPromptSchema } from '../models/index.js'
 
@@ -8,7 +8,7 @@ export const have_yard_prompt: PromptDefinition<YardPromptData, YardPromptData> 
   description: 'Applicants will enter information about their yard including how large it is and how many pets will share it.',
   schema: YardPromptSchema,
   prestage: {
-    recur: PreStageingRecurrence.INVALID,
+    recur: PromptPreStagingRecurrence.INVALID,
     process: (appRequest, config, allPeriodConfig, ctx, db): YardPromptData => {
       return {
         haveYard: true,

--- a/ui/src/lib/typed-client/schema.ts
+++ b/ui/src/lib/typed-client/schema.ts
@@ -2243,3 +2243,9 @@ export const enumRequirementType = {
    QUALIFICATION: 'QUALIFICATION' as const,
    WORKFLOW: 'WORKFLOW' as const
 }
+
+export const enumPromptPreStagingRecurrence = {
+  NEVER: 'NEVER' as const,
+  ALWAYS: 'ALWAYS' as const,
+  INVALID: 'INVALID' as const
+}


### PR DESCRIPTION
Previously prestage could be configured for recurrence of false; only stage data on first prompt use, or true; where data was always restaged when prompt was loaded.

To accommodate prompts which invalidate other prompts new recurrence options of **NEVER, ALWAYS, INVALID** have been added, and true/false options are maintained for backward compat.

In the instance of prestage recur being set **INVALID** the prompt will only prestage data if that prompt is currentl flagged as invalidate.  This will allow a dev to update certain data elements (maybe uncheck the 'confirmed' checkbox on a page asking for confirmation) when a previous prompt has designated a need to review a trailing prompts information by way of invalidUponChange.