### PR TITLE
Warn user when leaving prompt with unsaved changes

### DIFF
--- a/demos/src/default/definitions/prompts/cat.prompts.ts
+++ b/demos/src/default/definitions/prompts/cat.prompts.ts
@@ -40,12 +40,12 @@ export const applicant_seems_nice_prompt: PromptDefinition<NicePromptData> = {
   schema: NicePromptSchema,
   fetch: async (appRequest, config, data) => {
     // Simulate delayed fetching
-    await new Promise(resolve => setTimeout(resolve, 3000))
+    await new Promise(resolve => setTimeout(resolve, 1000))
     return { ratings: [0, 1, 2, 3, 4, 5] }
   },
   preload: async (appRequest, config, data) => {
     // Simulate delayed preloading
-    await new Promise(resolve => setTimeout(resolve, 3000))
+    await new Promise(resolve => setTimeout(resolve, 1000))
     return { seemsNice: false }
   },
   validate: (data, config) => {

--- a/demos/src/default/definitions/prompts/yard.prompts.ts
+++ b/demos/src/default/definitions/prompts/yard.prompts.ts
@@ -17,7 +17,7 @@ export const have_yard_prompt: PromptDefinition<YardPromptData, YardPromptData> 
     }
   },
   preload: async (appRequest, config, data, allPeriodConfig, ctx) => {
-    await new Promise(resolve => setTimeout(resolve, 3000))
+    await new Promise(resolve => setTimeout(resolve, 1000))
     return {
       haveYard: false,
       squareFootage: 6700,

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -6,7 +6,7 @@
    * the app request since the prompt should only be visible in a single spot.
    */
 
-  import { Form } from '@txstate-mws/carbon-svelte'
+  import { Form, confirmationStore } from '@txstate-mws/carbon-svelte'
   import type { FormStore } from '@txstate-mws/svelte-forms'
   import { Button } from 'carbon-components-svelte'
   import { getContext } from 'svelte'
@@ -27,10 +27,11 @@
 
   let store: FormStore | undefined
   let continueAfterSave = false
+  let unsavedChangesHandled = false
   $: hasPreviousPrompt = $nextHref.prevHref != null
   $: loading = false
 
-  async function handleBack () {
+  async function handleBack () {  
     const previousHref = $nextHref.prevHref
     if (previousHref) {
       // eslint-disable-next-line svelte/no-navigation-without-resolve -- already resolved
@@ -64,15 +65,28 @@
     loading = false
   }
 
+  async function leaveIfUnsavedChanges() {
+    return ($store?.hasUnsavedChanges) ? await confirmationStore.confirm('You have unsaved changes. Are you sure you want to leave?', { title: 'Unsaved Changes', yesText: 'Leave', noText: 'Stay', danger: true }) : true
+  }
+  
   // Remove the form from the DOM when navigating between prompts
   // to make sure state is reset
   let hideForm = false
-  beforeNavigate(() => {
-    hideForm = true
-    store = undefined // also clear out our bound store reference     
-    stagedprompts.clear() // clear references to staged prompts since we may be navigating to a different prompt that needs staging
-  })
+  beforeNavigate(async ({ cancel, to }) => {
+      if ($store.hasUnsavedChanges && !unsavedChangesHandled) {
+        cancel()
+        if (await leaveIfUnsavedChanges()) {
+          hideForm = true
+          store = undefined // also clear out our bound store reference     
+          stagedprompts.clear() // clear references to staged prompts since we may be navigating to a different prompt that needs staging
+          unsavedChangesHandled = true
+          goto(to.url.href)
+        }        
+      }      
+    }
+  )
   afterNavigate(async () => {
+    unsavedChangesHandled = false
     hideForm = false 
     await invalidate('request:apply') // required to redraw the nav tree if potential staged data affects prompt visibility or status
   })
@@ -80,7 +94,6 @@
 {#if loading}  
     <Loading />    
 {/if}
-
 {#if !hideForm}
   <div class="prompt-intro flow max-w-screen-md mx-auto pt-10 px-6">
     <!-- svelte-ignore a11y_autofocus -->


### PR DESCRIPTION
Prevent easy data loss when navigating away from a form with modified, but not saved, data

@wickning1 Note:  unsavedWarning was not viable as both beforeNavigate and afterNavigate run async and are not awaited in svelte.  So the form was hidden and store was being destroyed even as the warning modal was trying to be rendered.  

You would land with a blank screen and then the next nav you clicked will cause the warning modal to show as the form was no longer hidden and store rebuilt.

I implemented the confirmationStore from our CL, mirrored the warning modal, then canceled nav in beforeNavigate based on hasUnsavedChanges, prompted user, then ran a goto post if allowance was granted to leave.