### PR TITLE
PRE SCHEDULED RELEASE:  Update prompt validation to leverage new preloadAsDraft form prop

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4037,9 +4037,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4681,14 +4681,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -5374,12 +5374,12 @@
       }
     },
     "node_modules/toad-cache": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
-      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/toidentifier": {

--- a/api/src/prompt/prompt.resolver.ts
+++ b/api/src/prompt/prompt.resolver.ts
@@ -18,6 +18,11 @@ export class RequirementPromptResolver {
     return appRequestData[requirementPrompt.definition.key]
   }
 
+  @FieldResolver(type => Boolean, { description: 'Identifies if the prompt already has saved data.  Assists in determining if the user has previously interacted with this prompt.' })
+  async hasSavedData (@Ctx() ctx: RQContext, @Root() requirementPrompt: RequirementPrompt) {
+    return await ctx.svc(RequirementPromptService).hasSavedData(requirementPrompt)
+  }
+
   @FieldResolver(type => JsonData, { nullable: true, description: 'Any data that the API needs to provide to the UI to build the prompt form properly. For instance, it could pull reference information from an external system, e.g. a student\'s course schedule, for display in the prompt dialog. Null if the user is not currently allowed to update the prompt.' })
   async fetchedData (@Ctx() ctx: RQContext, @Root() requirementPrompt: RequirementPrompt, @Arg('schemaVersion', { nullable: true, description: 'Provide the schemaVersion at the time the UI was built. Will throw an error if the client is too old, so it knows to refresh.' }) savedAtVersion?: string) {
     if (savedAtVersion && savedAtVersion < promptRegistry.latestMigration()) throw new Error('Client is out of date. Please refresh.')

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -119,6 +119,11 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
     return this.removeUnauthorized(prompts)
   }
 
+  async hasSavedData (requirementPrompt: RequirementPrompt) {
+    const data = await this.svc(AppRequestServiceInternal).getData(requirementPrompt.appRequestInternalId)
+    return data[requirementPrompt.key] != null
+  }
+
   async getPreloadData (requirementPrompt: RequirementPrompt) {
     const [appRequest, allPeriodConfig, data] = await this.getRequirementPromptSupportDetail(requirementPrompt)
     const config = allPeriodConfig[requirementPrompt.key] ?? {}

--- a/demos/src/default/definitions/prompts/yard.prompts.ts
+++ b/demos/src/default/definitions/prompts/yard.prompts.ts
@@ -7,7 +7,7 @@ export const have_yard_prompt: PromptDefinition<YardPromptData, YardPromptData> 
   title: 'Tell us about your yard',
   description: 'Applicants will enter information about their yard including how large it is and how many pets will share it.',
   schema: YardPromptSchema,
-  prestage: {
+  /* prestage: {
     recur: PromptPreStagingRecurrence.INVALID,
     process: (appRequest, config, allPeriodConfig, ctx, db): YardPromptData => {
       return {
@@ -15,11 +15,11 @@ export const have_yard_prompt: PromptDefinition<YardPromptData, YardPromptData> 
         squareFootage: 10001
       }
     }
-  },
+  },*/
   preload: async (appRequest, config, data, allPeriodConfig, ctx) => {
     await new Promise(resolve => setTimeout(resolve, 1000))
     return {
-      haveYard: false,
+      haveYard: true,
       squareFootage: 6700,
       //TODO: Test for missing data causing early validation --totalPets: 67
     }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1387,9 +1387,9 @@
       }
     },
     "node_modules/@txstate-mws/svelte-forms": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@txstate-mws/svelte-forms/-/svelte-forms-2.1.4.tgz",
-      "integrity": "sha512-Qc/gA6pAiuRqHbMbq7cNooXyMNIbiR90iTKdB80EBvcg5w4hm1l3/NaRjS5XW18UCgHvqbY9tdzpffWhhMKLLQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@txstate-mws/svelte-forms/-/svelte-forms-2.1.5.tgz",
+      "integrity": "sha512-eT5PIy37YVlfk0YLlVH97W2004spGyyWypDglOmoKwkoBOkq7hXJr6QOwsNjxK1vrQkmJS9TcmqVG0RG3sXFgQ==",
       "dependencies": {
         "@txstate-mws/svelte-components": "^1.3.3",
         "@txstate-mws/svelte-store": "^1.0.7",
@@ -2065,9 +2065,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2215,9 +2215,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2550,9 +2550,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.356",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -3186,9 +3186,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.8.tgz",
-      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3311,9 +3311,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -5179,14 +5179,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -236,6 +236,7 @@ class API extends APIBase {
               description: true,
               answered: true,
               visibility: true,
+              hasSavedData: true,
               preloadData: true,
               fetchedData: true,
               configurationData: true,

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -84,7 +84,7 @@
     <h2 id="prompt-title" tabindex="-1" autofocus class="font-medium text-xl text-center">{prompt.title}</h2>
     <p class="text-center"> {prompt.description}</p>
   </div>
-  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
+  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData}  on:saved={onSaved} let:data>
     <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
     <svelte:fragment slot="submit" let:submitting>
       <div class='form-submit flex gap-12 justify-center mt-16'>

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -19,7 +19,6 @@
   import type { PageData } from '../../routes/requests/[id]/apply/[promptId]/$types.js'
   import ButtonLoadingIcon from './ButtonLoadingIcon.svelte'
   import { Loading } from "carbon-components-svelte";
-  import { promptRequiresValidation } from '../prompt-utils.js'
 
   export let data: PageData
   $: ({ prompt, appRequestForExport, dataVersion } = data)
@@ -50,7 +49,6 @@
   }
 
   async function onValidate (data: any) {
-    if (!promptRequiresValidation(prompt, data)) return { success: true, messages: []}
     const { messages } = await api.updatePrompt(prompt.id, data, true, dataVersion)
     return messages
   }
@@ -86,7 +84,7 @@
     <h2 id="prompt-title" tabindex="-1" autofocus class="font-medium text-xl text-center">{prompt.title}</h2>
     <p class="text-center"> {prompt.description}</p>
   </div>
-  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preload={prompt.preloadData} on:saved={onSaved} let:data>
+  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
     <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
     <svelte:fragment slot="submit" let:submitting>
       <div class='form-submit flex gap-12 justify-center mt-16'>

--- a/ui/src/internal/prompt-utils.ts
+++ b/ui/src/internal/prompt-utils.ts
@@ -1,6 +1,5 @@
 import { uiRegistry } from '../local'
 import { reviewerRequirementTypes } from '$internal'
-import { deepEqual } from './util.js'
 
 export const stagedprompts = new Set<string>()
 
@@ -31,8 +30,3 @@ export const coalesceAppRequestPrompts = (appRequest, prompts) => {
   })
   return appRequest
 } 
-
-export const promptRequiresValidation = (prompt, data) => {
-  if (prompt.preloadData == null) return true // if there is no prompt data, validate to show required field errors
-  return (!deepEqual(prompt.preloadData, data)) ? true : false // if there is prompt data, only validate if the data has changed to avoid showing validation errors on load before the user has a chance to make any changes
-}

--- a/ui/src/internal/util.ts
+++ b/ui/src/internal/util.ts
@@ -20,13 +20,3 @@ export function machineDateTime (dt: DateTime | string) {
 export function booleanToWord (bool?: boolean) {
   return bool ? 'Yes' : 'No'
 }
-
-export function deepEqual(obj1: any, obj2: any): boolean {  
-  if (obj1 === obj2) return true
-  if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) return false
-  const keys1 = Object.keys(obj1)
-  const keys2 = Object.keys(obj2)
-  if (keys1.length !== keys2.length) return false
-  for (const key of keys1) if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key]))  return false
-  return true
-}

--- a/ui/src/lib/typed-client/schema.graphql
+++ b/ui/src/lib/typed-client/schema.graphql
@@ -1614,6 +1614,11 @@ type RequirementPrompt {
   Extra configuration data that is relevant for this prompt. This configuration is explicitly gathered from related requirements and prompts by the gatherConfig function in the prompt definition.
   """
   gatheredConfigData: JsonData!
+
+  """
+  Identifies if the prompt already has saved data.  Assists in determining if the user has previously interacted with this prompt.
+  """
+  hasSavedData: Boolean!
   id: ID!
 
   """

--- a/ui/src/lib/typed-client/schema.ts
+++ b/ui/src/lib/typed-client/schema.ts
@@ -713,6 +713,8 @@ export interface RequirementPrompt {
     fetchedData: (Scalars['JsonData'] | null)
     /** Extra configuration data that is relevant for this prompt. This configuration is explicitly gathered from related requirements and prompts by the gatherConfig function in the prompt definition. */
     gatheredConfigData: Scalars['JsonData']
+    /** Identifies if the prompt already has saved data.  Assists in determining if the user has previously interacted with this prompt. */
+    hasSavedData: Scalars['Boolean']
     id: Scalars['ID']
     /** When true, this prompt has been invalidated by the answer to another prompt. The `answered` field will remain true so be sure to check this field as well when determining whether the prompt is complete. */
     invalidated: Scalars['Boolean']
@@ -1658,6 +1660,8 @@ export interface RequirementPromptGenqlSelection{
     schemaVersion?: (Scalars['String'] | null)} } | boolean | number
     /** Extra configuration data that is relevant for this prompt. This configuration is explicitly gathered from related requirements and prompts by the gatherConfig function in the prompt definition. */
     gatheredConfigData?: boolean | number
+    /** Identifies if the prompt already has saved data.  Assists in determining if the user has previously interacted with this prompt. */
+    hasSavedData?: boolean | number
     id?: boolean | number
     /** When true, this prompt has been invalidated by the answer to another prompt. The `answered` field will remain true so be sure to check this field as well when determining whether the prompt is complete. */
     invalidated?: boolean | number
@@ -2242,10 +2246,4 @@ export const enumRequirementType = {
    PREQUAL: 'PREQUAL' as const,
    QUALIFICATION: 'QUALIFICATION' as const,
    WORKFLOW: 'WORKFLOW' as const
-}
-
-export const enumPromptPreStagingRecurrence = {
-  NEVER: 'NEVER' as const,
-  ALWAYS: 'ALWAYS' as const,
-  INVALID: 'INVALID' as const
 }

--- a/ui/src/lib/typed-client/types.ts
+++ b/ui/src/lib/typed-client/types.ts
@@ -1824,6 +1824,9 @@ export default {
             "gatheredConfigData": [
                 51
             ],
+            "hasSavedData": [
+                38
+            ],
             "id": [
                 46
             ],

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -168,7 +168,6 @@
 
   function onPromptValidate (prompt: any) {
     return async (data: any) => {
-      if (!promptRequiresValidation(prompt, data)) return { success: true, messages: []}
       const response = await api.updatePrompt(prompt.id, data, true)
       return response.messages
     }


### PR DESCRIPTION
Previously validation was firing on empty fields that were returned as part of the APIs preload operation.  Bad user experience

* Update has API inform the UI if data has been previously stored in the prompt, and set `preloadAsDraft` value accordingly, to prevent early validation on partial form field loading

