### PR TITLE
Trigger api.getAccess after application creation (Start application)

### DIFF
--- a/ui/src/routes/+layout.ts
+++ b/ui/src/routes/+layout.ts
@@ -5,6 +5,7 @@ import { unifiedAuth } from '@txstate-mws/sveltekit-utils'
 export const load: LayoutLoad = async input => {
   api.fetch = input.fetch
   await unifiedAuth.handle(api, input)
+  input.depends('api:getAccess')
   const access = await api.getAccess()
   return { access }
 }

--- a/ui/src/routes/dashboards/applicant/+page.svelte
+++ b/ui/src/routes/dashboards/applicant/+page.svelte
@@ -266,6 +266,7 @@
   }
 
   async function onSaved () {
+    await invalidate('api:getAccess')
     await goto(resolve(`/requests/${lastInsertedId}/apply`))
   }
 


### PR DESCRIPTION
Currently the **Start application** button continues to show post an application being created, when returning via breadcrumb menu

Fix:
1.  On successful start application, invalidate dependency `api:getAccess`. 
 2. Add `api:getAccess` dependency to root layout.ts file.