### PR TITLE
PRE SCHEDULED RELEASE: Bug fix, missed default route update on approve/page.ts for eligible apps filter

### DIFF
--- a/ui/src/routes/requests/[id]/approve/+page.ts
+++ b/ui/src/routes/requests/[id]/approve/+page.ts
@@ -7,8 +7,8 @@ import { excludeAppsByIneligibiltyPhase } from '$internal'
 export const load: PageLoad = async ({ params, parent }) => {
   const { basicRequestData } = await parent()
   // exclude previously ineligible applications from default landing 
-  excludeAppsByIneligibiltyPhase([basicRequestData], [enumApplicationPhase.PREQUAL, enumApplicationPhase.QUALIFICATION])
-  const key = basicRequestData.applications[0]?.programKey
+  const eligibleApps = excludeAppsByIneligibiltyPhase([basicRequestData], [enumApplicationPhase.PREQUAL, enumApplicationPhase.QUALIFICATION])
+  const key = eligibleApps[0]?.applications[0]?.programKey
   if (!key) throw error(404, 'Program not found')
   throw redirect(303, `${base}/requests/${params.id}/approve/${key}`)
 }


### PR DESCRIPTION
Default route for requests/[id]/approve wasn't updated to restrict apps by eligibility phase.

* page.ts updated to correct