### PR TITLE
PRE SCHEDULE RELEASE:  Bug fix for loading component toggling quickly on reviewer page

### DIFF
--- a/demos/src/default/definitions/prompts/cat.prompts.ts
+++ b/demos/src/default/definitions/prompts/cat.prompts.ts
@@ -40,12 +40,12 @@ export const applicant_seems_nice_prompt: PromptDefinition<NicePromptData> = {
   schema: NicePromptSchema,
   fetch: async (appRequest, config, data) => {
     // Simulate delayed fetching
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise(resolve => setTimeout(resolve, 250))
     return { ratings: [0, 1, 2, 3, 4, 5] }
   },
   preload: async (appRequest, config, data) => {
     // Simulate delayed preloading
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise(resolve => setTimeout(resolve, 250))
     return { seemsNice: false }
   },
   validate: (data, config) => {

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -125,6 +125,21 @@
   ].filter(s => (!!s.requirements[0]?.workflowStage) || (s.requirements.length > 0 && s.requirements.some(r => r.prompts.length > 0)))
   $: applicationStatusInfo = getApplicationStatusInfo(application.status, appRequest.phase, appRequest.closedAt)
   $: loading = false
+  let showLoading = false
+  let loadingTimer: NodeJS.Timeout | undefined
+  $: {
+    if (loading) {
+      if (!loadingTimer) {
+        loadingTimer = setTimeout(() => {
+          showLoading = true
+        }, 500)
+      }
+    } else {
+      clearTimeout(loadingTimer)
+      loadingTimer = undefined
+      showLoading = false
+    }
+  }
 
   type PromptExtraData = Awaited<ReturnType<typeof api.getPromptData>>
   type Prompt = PageData['appRequest']['applications'][0]['requirements'][0]['prompts'][0]
@@ -226,7 +241,7 @@
     }
   }
 </script>
-{#if loading}  
+{#if showLoading}  
     <Loading />    
 {/if}
 


### PR DESCRIPTION
Issue:  Data loader(loading) component was showing on all data requests even with durations less than 500ms.

* Added a delay to loading transitions on approve/[programKey]/+page.svelte to prevent flickering