### PR TITLE
PRE SCHEDULED RELEASE: Remove default AJV coercion for submitted prompt data

### DIFF
--- a/api/src/registry/prompt.ts
+++ b/api/src/registry/prompt.ts
@@ -442,7 +442,7 @@ const tagListCache = new Cache(async (key: { category: string, search?: string }
 export const registryAjv = new Ajv({
   allErrors: true,
   strictSchema: false,
-  coerceTypes: true
+  coerceTypes: false
 })
 
 addFormats(registryAjv)


### PR DESCRIPTION
Issue:  AJV coercion of data types was resulting in `unsavedWarning` triggering when values of "true" were converted to true and then returned post validation.

Fix:  Change `coerceTypes` for AJV validation to **false**.  This will also require RQ app devs to be explicit specifying components data types and ensure they match with validation schema object types.  Type mismatches will result in an immediate 'invalid prompt data' toast message.