### PR TITLE
Enhancement: Remove HTML considerations from internal 'notes' functionality txstate-etc/reqquest-txstate#340

### DIFF
--- a/demos/src/simple/testdata.ts
+++ b/demos/src/simple/testdata.ts
@@ -108,7 +108,7 @@ export const simpleTestMigrations: DatabaseMigration[] = [
       const reviewer2 = await AccessDatabase.upsertAccessUser({ login: 'reviewer2', fullname: 'Robert Reviewer', groups: ['sudoers'] })
       const reviewers = [reviewer1, reviewer2]
       const noteTexts = [
-        'Applicant submitted all required documentation on time.',
+        'Applicant submitted all required documentation on time. <b>Bold</b>. https://www.txst.edu/.',
         'Residency verification looks good — ID matches the address provided.',
         'Had a phone conversation with applicant to clarify employment details.',
         "Supervisor confirmed applicant's work history via email.",
@@ -120,7 +120,7 @@ export const simpleTestMigrations: DatabaseMigration[] = [
         'All checks passed. This application is ready for final approval.'
       ]
       for (let i = 0; i < noteTexts.length; i++) {
-        await addAppRequestNote(1, reviewers[i % 2].internalId, `<p>${noteTexts[i]}</p>`)
+        await addAppRequestNote(1, reviewers[i % 2].internalId, `${noteTexts[i]}`)
       }
     }
   }

--- a/ui/src/lib/components/CommentCard.svelte
+++ b/ui/src/lib/components/CommentCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ActionSet, type ActionItem } from '@txstate-mws/carbon-svelte'
   import { DateTime } from 'luxon'
+  import { htmlEncode } from 'txstate-utils'
 
   /**
    * The TEXT content of the comment.
@@ -44,7 +45,7 @@
 
 <div class="comment-card">
   <div class="comment-box" class:noborder class:hasactions={actions.length > 0}>
-    <div class="comment-content"><p>{content}</p></div>
+    <div class="comment-content"><p>{@html htmlEncode(content)}</p></div>
     {#if actions.length}
       <div class="comment-actions">
         <ActionSet {actions} noPrimaryAction small forceOverflow />

--- a/ui/src/lib/components/CommentCard.svelte
+++ b/ui/src/lib/components/CommentCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ActionSet, type ActionItem } from '@txstate-mws/carbon-svelte'
   import { DateTime } from 'luxon'
-  import { htmlEncode } from 'txstate-utils'
+  import { htmlEncode, isBlank } from 'txstate-utils'
 
   /**
    * The TEXT content of the comment.
@@ -41,11 +41,30 @@
   export let noborder = false
 
   $: createdAtDt = typeof createdAt === 'string' ? DateTime.fromISO(createdAt) : createdAt
+
+  // NOTE: Noticed that htmlEncode doesn't encode equal signs,
+  // but included here just in case that changes as unencoding doesn't cause issues.
+  function unencodeUrl (str: string) {
+    if (isBlank(str)) return ''
+    const map = new Map<string, string>([
+      ['&amp;', '&'],
+      ['&#x3D;', '=']
+    ])
+    return str.trim().replace(/&(amp|#x3D);/g, (m: string) => map.get(m) ?? '')
+  }
+
+  // People often put punctuation at the end or enclose url's in parentheses or quotes so do not include
+  // https://www.youtube.com/watch?v&#x3D;pYBrK1O4UEQ&amp;list&#x3D;UUHdD1ujwX1fCB0CiamefSWA.
+  //   => href="https://www.youtube.com/watch?v=pYBrK1O4UEQ&list=UUHdD1ujwX1fCB0CiamefSWA"
+  function clickableUrl(str: string) {
+    return str.replace(/(\bhttps?:\/\/([^.,!?:)\n\r\t '"]+|[.,!?:)][^\n\r\t '")])+)/g, (m: string) => `<a href="${unencodeUrl(m)}" target="_blank">${m}</a>`)
+  }
+
 </script>
 
 <div class="comment-card">
   <div class="comment-box" class:noborder class:hasactions={actions.length > 0}>
-    <div class="comment-content"><p>{@html htmlEncode(content)}</p></div>
+    <div class="comment-content"><p>{@html clickableUrl(htmlEncode(content))}</p></div>
     {#if actions.length}
       <div class="comment-actions">
         <ActionSet {actions} noPrimaryAction small forceOverflow />


### PR DESCRIPTION
- Update sample notes to match how tags would not be included in text box
- Sanitize/htmlEncode output with our own txstate-utils library as cannot use svelte if we wish to modify afterwards
- Add "Magic Links" to make detected URLs clickable, and exclude common punctuation that is often added to text.