### PR TITLE
Ineligible accordion with default for review screens

### DIFF
--- a/ui/src/internal/components/ApplicationDetailsView.svelte
+++ b/ui/src/internal/components/ApplicationDetailsView.svelte
@@ -4,7 +4,7 @@
   import { Button, InlineNotification, Tooltip } from 'carbon-components-svelte'
   import Edit from 'carbon-icons-svelte/lib/Edit.svelte'
   import type { AnsweredPrompt, PromptSection, AppRequestForDetails, ApplicationForDetails, Scalars } from '$lib'
-  import { enumRequirementType } from '$lib'
+  import { enumRequirementType, enumIneligiblePhases, enumApplicationStatus } from '$lib'
   import type { UIRegistry } from '../../lib/registry.js'
   import RenderDisplayComponent from './RenderDisplayComponent.svelte'
   import ApplicantProgramList from './ApplicantProgramList.svelte'
@@ -30,7 +30,9 @@
   const CORRECTABLE_STATUSES = ['STARTED', 'READY_TO_SUBMIT', 'DISQUALIFIED']
 
   $: canMakeCorrections = CORRECTABLE_STATUSES.includes(appRequest.status)
-
+  $: eligibleApplications = applications.filter(a => a.ineligiblePhase == null)
+  $: ineligibleApplications = applications.filter(a => a.ineligiblePhase === enumIneligiblePhases.PREQUAL || a.ineligiblePhase === enumIneligiblePhases.QUALIFICATION)
+  
   // Group prompts by sections, with reviewer prompts nested within application sections
   $: sections = (() => {
     const sections: PromptSection[] = []
@@ -105,7 +107,15 @@
         {/if}
 
         <!-- Application Status List -->
-        <ApplicantProgramList {applications} {appRequest} viewMode={statusDisplay === 'tags'} {showTooltipsAsText} />
+        {#if eligibleApplications.length > 0}
+          <ApplicantProgramList applications={eligibleApplications} {appRequest} viewMode={statusDisplay === 'tags'} {showTooltipsAsText} />
+        {/if}
+        <!-- Ineligible Status List -->
+         {#if ineligibleApplications.length > 0}
+            <Panel title="Ineligible programs" expandable={true} expanded={(eligibleApplications.length === 0)}>
+              <ApplicantProgramList applications={ineligibleApplications} {appRequest} viewMode={statusDisplay === 'tags'} {showTooltipsAsText} />
+            </Panel>
+         {/if}         
       </div>
     </section>
 

--- a/ui/src/local/rc/AssessCriticalThinkingDisplay.svelte
+++ b/ui/src/local/rc/AssessCriticalThinkingDisplay.svelte
@@ -6,6 +6,6 @@
 </script>
 <p class="text-xs">Is the issue real?</p>
 <p>{booleanToWord(data?.realIssue)}</p>
-<p class="text-xs">Is the proposed feature/change technologically feasible? /p>
+<p class="text-xs">Is the proposed feature/change technologically feasible? </p>
 <p>{booleanToWord(data?.feasable)}</p>
 

--- a/ui/src/routes/requests/[id]/apply/programs/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/programs/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Button } from 'carbon-components-svelte'
+  import { Panel } from '@txstate-mws/carbon-svelte'
   import { getContext } from 'svelte'
   import type { Writable } from 'svelte/store'
   import { afterNavigate } from '$app/navigation'
@@ -27,15 +28,25 @@
 </script>
 
 <ProgressNavContainer title="Your potential programs" subtitle='Select "Start" to answer additional qualifying questions about the benefits you may be eligible for.'>
-  {@const eligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase !== enumIneligiblePhases.PREQUAL)}
+  {@const eligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase == null)}
   <div class="max-w-screen-md mx-auto">    
-    <ApplicantProgramList applications={eligibleApplicationsForNav} appRequest={appRequestForExport} />
+    {#if eligibleApplicationsForNav.length > 0} 
+      <ApplicantProgramList applications={eligibleApplicationsForNav} appRequest={appRequestForExport} />
+    {/if}
     {#if eligibleApplicationsForNav.some(a => a.status === enumApplicationStatus.INELIGIBLE)}
       <div class="program-helptext">
         If you believe you should be eligible, read the tooltips above and review your answers. If you believe there is an error, please contact us.
       </div>
     {/if}
   </div>
+  {@const ineligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase === enumIneligiblePhases.PREQUAL || a.ineligiblePhase === enumIneligiblePhases.QUALIFICATION)}
+  {#if ineligibleApplicationsForNav.length > 0}  
+    <div class="max-w-screen-md mx-auto">    
+      <Panel title="Ineligible programs" expandable={true} expanded={true}>
+        <ApplicantProgramList applications={ineligibleApplicationsForNav} appRequest={appRequestForExport} />
+      </Panel>
+    </div>
+  {/if}
   <div class='form-submit flex gap-12 justify-center mt-16'>
     {#if prevHref}
       <Button kind="ghost" href={prevHref}>Back</Button>

--- a/ui/src/routes/requests/[id]/apply/review/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/review/+page.svelte
@@ -53,7 +53,7 @@
 <div class:max-w-screen-md={uiRegistry.config.applicantReviewMaxWidth !== false} class:mx-auto={uiRegistry.config.applicantReviewMaxWidth !== false}>
   <ApplicationDetailsView
     appRequest={appRequestForExport}
-    applications={applicationsForNav.filter(a => a.ineligiblePhase !== enumIneligiblePhases.PREQUAL)}
+    applications={applicationsForNav}
     appData={appRequestForExport.data}
     {prequalPrompts}
     {postqualPrompts}


### PR DESCRIPTION
Previously prequal ineligible programs were completely removed from applicant UI, and qual ineligible were maintained in the Program list.

https://github.com/txstate-etc/reqquest-txstate/issues/301

Change:  
1. For `Program Review` the ineligible apps are show in a separate expandable panel with default to expanded.
2. For `Review application` the ineligible apps are show in a separate expandable panel with default to NOT expanded.
3. If either eligible or ineligible have no programs, those sections are not shown.