### PR TITLE
Avoid unsaved warnings when a prompt contains FieldUpload

### DIFF
--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -306,10 +306,13 @@ class API extends APIBase {
             type
             arg
           }
+          appRequest {
+            data
+          }
         }
       }
     `, { promptId, data, validateOnly, dataVersion })
-    return this.mutationForDialog(response.updatePrompt)
+    return { ...this.mutationForDialog(response.updatePrompt), data: response.updatePrompt.appRequest.data }
   }
 
   async updateConfiguration (periodId: string, definitionKey: string, data: any, validateOnly: boolean) {

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -23,13 +23,12 @@
   export let data: PageData
   $: ({ prompt, appRequestForExport, dataVersion } = data)
   $: def = uiRegistry.getPrompt(prompt.key)
-  $: unsavedWarningCheck = true // TODO: Temp fix to prevent unsavedWarn check from triggering after save and continue
   const nextHref = getContext<Writable<{ nextHref: ResolvedPathname, prevHref: ResolvedPathname | undefined }>>('nextHref')
 
   let store: FormStore | undefined
   let continueAfterSave = false
   $: hasPreviousPrompt = $nextHref.prevHref != null
-  $: loading = false  
+  $: loading = false
 
   async function handleBack () {
     const previousHref = $nextHref.prevHref
@@ -41,12 +40,12 @@
 
  async function onSubmit (data: any) {
     loading = true
-    const { success, messages } = await api.updatePrompt(prompt.id, data, false, dataVersion)   
-    if (!success) loading = false    
+    const { success, messages, data: newData } = await api.updatePrompt(prompt.id, data, false, dataVersion)
+    if (!success) loading = false
     return {
       success,
       messages,
-      data
+      data: newData[prompt.key]
     }
   }
 
@@ -56,17 +55,13 @@
   }
 
   async function onSaved () {
-    unsavedWarningCheck = false
     await invalidate('request:apply')
     if (continueAfterSave && prompt.answered) {
       // eslint-disable-next-line svelte/no-navigation-without-resolve -- already resolved
       stagedprompts.clear()
       await goto($nextHref.nextHref)
-    } else {
-      await store?.setData(appRequestForExport.data[prompt.key] as object)
     }
     loading = false
-    unsavedWarningCheck = true
   }
 
   let lastPromptId: string | undefined
@@ -74,14 +69,14 @@
     lastPromptId = prompt.id
     store = undefined
   }
-  afterNavigate(async (navigation) => { 
+  afterNavigate(async (navigation) => {
     if (!continueAfterSave) { // navigating away from current prompt without using the continue button ... remove prompt staging and invalidate to ensure any changes are reflected in nav
       stagedprompts.clear()
       await invalidate('request:apply')
-    }    
+    }
   })
 </script>
-{#if loading} 
+{#if loading}
   <Loading />
 {/if}
 
@@ -91,7 +86,7 @@
     <h2 id="prompt-title" tabindex="-1" autofocus class="font-medium text-xl text-center">{prompt.title}</h2>
     <p class="text-center"> {prompt.description}</p>
   </div>
-  <Form bind:store hideFallbackMessage unsavedWarning={unsavedWarningCheck} submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData}  on:saved={onSaved} let:data>
+  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
     <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
     <svelte:fragment slot="submit" let:submitting>
       <div class='form-submit flex gap-12 justify-center mt-16'>


### PR DESCRIPTION
FieldUpload was an example form control that has different data before and after submit, since after submit it's information about a previous upload rather than literal file data. Solution was to use svelte-forms a little more carefully and give it the newer form of the data so that its hasUnsavedChanges could be calculated properly. It's possible there are other places in ReqQuest that could use this treatment, like the reviewer UI - I did not evaluate that at this time.