### PR TITLE
Provide tool tip capabilities for QUALIFYING requirements when response message is provided

### DIFF
--- a/demos/src/default/definitions/requirements/dog.requirements.ts
+++ b/demos/src/default/definitions/requirements/dog.requirements.ts
@@ -8,12 +8,13 @@ export const must_exercise_your_dog_req: RequirementDefinition<ExerciseConfigReq
   title: 'Agreement to Exercise the Dog',
   navTitle: 'Exercise Per Week',
   description: 'The applicant must exercise their dog a certain number of hours a week.',
-  promptKeys: ['must_exercise_your_dog_prompt'],
+  // promptKeys: ['must_exercise_your_dog_prompt'],
   resolve: (data, config) => {
-    const exerciseData = data.must_exercise_your_dog_prompt as ExercisePromptData
-    if (exerciseData?.exerciseHours == null) return { status: RequirementStatus.PENDING }
-    if (exerciseData.exerciseHours >= config.minExerciseHours) return { status: RequirementStatus.MET }
-    return { status: RequirementStatus.WARNING, reason: `You must exercise your dog ${config.minExerciseHours} hours a week.` }
+  //  const exerciseData = data.must_exercise_your_dog_prompt as ExercisePromptData
+  //  if (exerciseData?.exerciseHours == null) return { status: RequirementStatus.PENDING }
+  //  if (exerciseData.exerciseHours >= config.minExerciseHours) return { status: RequirementStatus.MET }
+  //  return { status: RequirementStatus.WARNING, reason: `You must exercise your dog ${config.minExerciseHours} hours a week.` }
+    return { status: RequirementStatus.MET, reason: 'Oprah - Everybody gets a dog!!!' }
   },
   configuration: {
     validate: config => {

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -357,7 +357,7 @@ class API extends APIBase {
   static splitPromptsForApplicant<P extends { id: string, key: string, visibility: PromptVisibility, moot: boolean }, R extends { type: RequirementType, status: RequirementStatus, statusReason: string | null, prompts: P[] }, A extends { title: string, ineligiblePhase: IneligiblePhases | null, requirements: R[] }>(applications: A[]) {
     type ReturnPrompt = P & { statusReasons: { status: string, statusReason: string | null, programName: string }[] }
     type ReturnRequirement = R & { prompts: ReturnPrompt[] }
-    type ReturnApplication = A & { requirements: ReturnRequirement[], completionStatus: CompletionStatus, hasWarning: boolean, warningReasons: string[], ineligibleReasons: string[] }
+    type ReturnApplication = A & { requirements: ReturnRequirement[], completionStatus: CompletionStatus, hasWarning: boolean, warningReasons: string[], ineligibleReasons: string[], metReasons: string[]}
     const prequalPrompts: ReturnPrompt[] = []
     const postqualPrompts: ReturnPrompt[] = []
     const qualPrompts: ReturnPrompt[] = []
@@ -435,6 +435,8 @@ class API extends APIBase {
       const warningReasonsFull: string[] = []
       const ineligibleReasons: string[] = []
       const ineligibleReasonsFull: string[] = []
+      const metReasons: string[] = []
+      const metReasonsFull: string[] = []
       let hasWarning = false
       let hasWarningForNav = false
       for (const req of reqsForCompletion) {
@@ -456,14 +458,21 @@ class API extends APIBase {
             if (requirementTypesForNavigation.has(req.type)) ineligibleReasons.push(req.statusReason)
             if (application.ineligiblePhase !== enumIneligiblePhases.PREQUAL || req.type !== enumRequirementType.PREQUAL) ineligibleReasonsFull.push(req.statusReason)
           }
+        } else if (req.status === enumRequirementStatus.MET) {
+          completionStatus = 'ELIGIBLE'
+          if (requirementTypesForNavigation.has(req.type)) completionStatusForNav = 'ELIGIBLE'
+          if (req.statusReason) {
+            if (requirementTypesForNavigation.has(req.type)) metReasons.push(req.statusReason)
+            metReasonsFull.push(req.statusReason)
+          }          
         }
       }
-      applicationsReviewWithDupes.push({ ...application, requirements: requirementsReviewWithDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, hasWarning })
-      applicationsReviewNoDupes.push({ ...application, requirements: requirementsReviewNoDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, hasWarning })
-      applicationsForNavWithDupes.push({ ...application, requirements: requirementsForNavWithDupes, completionStatus: completionStatusForNav, warningReasons, ineligibleReasons, hasWarning: hasWarningForNav })
-      applicationsForNavNoDupes.push({ ...application, requirements: requirementsForNavNoDupes, completionStatus: completionStatusForNav, warningReasons, ineligibleReasons, hasWarning: hasWarningForNav })
-      applicationsAcceptWithDupes.push({ ...application, requirements: requirementsAcceptWithDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, hasWarning })
-      applicationsAcceptNoDupes.push({ ...application, requirements: requirementsAcceptNoDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, hasWarning })
+      applicationsReviewWithDupes.push({ ...application, requirements: requirementsReviewWithDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, metReasons: metReasonsFull, hasWarning })
+      applicationsReviewNoDupes.push({ ...application, requirements: requirementsReviewNoDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, metReasons: metReasonsFull, hasWarning })
+      applicationsForNavWithDupes.push({ ...application, requirements: requirementsForNavWithDupes, completionStatus: completionStatusForNav, warningReasons, ineligibleReasons, metReasons: metReasonsFull, hasWarning: hasWarningForNav })
+      applicationsForNavNoDupes.push({ ...application, requirements: requirementsForNavNoDupes, completionStatus: completionStatusForNav, warningReasons, ineligibleReasons, metReasons: metReasonsFull, hasWarning: hasWarningForNav })
+      applicationsAcceptWithDupes.push({ ...application, requirements: requirementsAcceptWithDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, metReasons: metReasonsFull, hasWarning })
+      applicationsAcceptNoDupes.push({ ...application, requirements: requirementsAcceptNoDupes, completionStatus, warningReasons: warningReasonsFull, ineligibleReasons: ineligibleReasonsFull, metReasons: metReasonsFull, hasWarning })
     }
     for (const prompts of Object.values(promptsByKey)) {
       const statusReasons = prompts.map(p => p.statusReasons[0])

--- a/ui/src/internal/components/ApplicantProgramListTooltip.svelte
+++ b/ui/src/internal/components/ApplicantProgramListTooltip.svelte
@@ -5,9 +5,14 @@
   export let application: ApplicationForDetails
 </script>
 
-{#if application.warningReasons.length || application.ineligibleReasons.length}
+{#if application.warningReasons.length || application.ineligibleReasons.length || application.metReasons.length}
   <Tooltip align="end" direction="bottom" triggerText="" class="reason-tooltip">
-    {#if application.ineligibleReasons.length}
+    {#if application.metReasons.length > 0}
+      <p><strong>Eligible Because:</strong></p>
+      {#each application.metReasons as reason (reason)}
+        <p>{reason}</p>
+      {/each}
+    {:else if application.ineligibleReasons.length}
       <p><strong>Ineligible Because:</strong></p>
       {#each application.ineligibleReasons as reason (reason)}
         <p>{reason}</p>
@@ -16,7 +21,7 @@
       <p><strong>Warnings:</strong></p>
       {#each application.warningReasons as reason (reason)}
         <p>{reason}</p>
-      {/each}
+      {/each}    
     {/if}
   </Tooltip>
 {/if}

--- a/ui/src/internal/components/ApplicantProgramListTooltip.svelte
+++ b/ui/src/internal/components/ApplicantProgramListTooltip.svelte
@@ -7,7 +7,7 @@
 
 {#if application.warningReasons.length || application.ineligibleReasons.length || application.metReasons.length}
   <Tooltip align="end" direction="bottom" triggerText="" class="reason-tooltip">
-    {#if application.metReasons.length > 0}
+    {#if application.metReasons.length}
       <p><strong>Eligible Because:</strong></p>
       {#each application.metReasons as reason (reason)}
         <p>{reason}</p>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -50,9 +50,10 @@ export interface ApplicationForDetails {
   status: ApplicationStatus
   statusReason?: string | null
   completionStatus: CompletionStatus
-  hasWarning: boolean
+  hasWarning: boolean  
   warningReasons: string[]
   ineligibleReasons: string[]
+  metReasons: string[]
   requirements: {
     id: string
     type: RequirementType

--- a/ui/src/routes/requests/[id]/apply/review/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/review/+page.svelte
@@ -42,7 +42,7 @@
   }
 
   afterNavigate(({ from }) => {
-    if (from?.url.pathname) previousHref = from.url.pathname + from.url.search
+    if (from?.url?.pathname) previousHref = from.url.pathname + from.url.search
     const h2 = document.querySelector('h2')
     if (h2) {
       h2.tabIndex = -1


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/351

Issue:

This item comes up in va-cert, example is **In state tuition.**  Currently there are a number programs that are only determined eligible by prequal requirements.  As such, when review screen is shown the program has a blue check mark, but no 'Continue' button like show for programs that have QUAL requirements.  Per feedback, this could cause confusion to end user as to why some complete programs only have blue check marks, and some have blue check marks and a 'Complete' link.

Solution:

On api call to function getAppRequestForExport, all requirement reasons (including for MET reqs) is included in return.  The enhancement is to include tooltips on the Review Program and Submit pages for qualifying requirements if response messages are included.

A downstream RQ app dev, for programs that have no QUAL reqs can then included a pre-MET QUAL requirement, that has a reason that can provide additional detail to the applicant as needed.

Example as in RQ default demo:
<img width="1457" height="628" alt="image" src="https://github.com/user-attachments/assets/daab3552-0701-4c9c-bec1-ab89b7ab587d" />
