### PR TITLE
Remove tagset for ineligible programs when applicant is viewing submitted app from card action menu

### DIFF
--- a/ui/src/internal/components/ApplicantProgramList.svelte
+++ b/ui/src/internal/components/ApplicantProgramList.svelte
@@ -131,8 +131,12 @@
           <Button size="small" kind={programStatus === 'complete' ? 'ghost' : programStatus === 'revisit' ? 'secondary' : 'primary'} href={programFirstPrompt}>{ucfirst(programStatus)}</Button>
         {/if}
       {:else}
-        {@const statusInfo = getApplicationStatusInfo(application.status, appRequest.phase, appRequest.closedAt)}
-        <TagSet tags={[{ type: statusInfo.color, label: statusInfo.label }]} />
+        {#if application.completionStatus !== enumApplicationStatus.INELIGIBLE}
+          {@const statusInfo = getApplicationStatusInfo(application.status, appRequest.phase, appRequest.closedAt)}
+          <TagSet tags={[{ type: statusInfo.color, label: statusInfo.label }]} />
+        {:else}
+          <Close size={32} class="status-icon-ineligible" />
+        {/if}
         <ApplicantProgramListTooltip {application} />
       {/if}
     </div>


### PR DESCRIPTION
https://github.com/txstate-etc/va-certification/issues/242

Issue:

Post submitting an application for review, an applicant can open and view their eligible and ineligible program lists in full.  When viewing items in the ineligible section, tags with obfuscated status were showing as 'In progress' when those programs would never be reviewed.

Solution:

Replace tagset with X icon when in view mode for applicant ineligible programs.  This would match accurately with what they saw before submission