### PR TITLE
Relabel 'complete' button to 'revisit' for eligible complete programs

### DIFF
--- a/ui/src/internal/components/ApplicantProgramList.svelte
+++ b/ui/src/internal/components/ApplicantProgramList.svelte
@@ -128,7 +128,7 @@
         {#if optedOutPrograms[application.id]}
           <p>Opted out</p>
         {:else if programFirstPrompt && programStatus !== 'ineligible'}
-          <Button size="small" kind={programStatus === 'complete' ? 'ghost' : programStatus === 'revisit' ? 'secondary' : 'primary'} href={programFirstPrompt}>{ucfirst(programStatus)}</Button>
+          <Button size="small" kind={programStatus === 'complete' ? 'ghost' : programStatus === 'revisit' ? 'secondary' : 'primary'} href={programFirstPrompt}>{ucfirst((programStatus !== 'complete') ? programStatus : 'revisit')}</Button>
         {/if}
       {:else}
         {@const statusInfo = getApplicationStatusInfo(application.status, appRequest.phase, appRequest.closedAt)}


### PR DESCRIPTION
https://github.com/txstate-etc/va-certification/issues/209

Issue:
Some confusion over **Complete** button rendering next to some eligible programs but not others.  Button is necessary so that you can return to program specific questions, but the word doesn't convey the correct intent. 

Solution:
Button is going to be maintained as a ghost button, but instead of 'Complete' will also show 'Revisit' to make intent more apparent to applicants.
