### PR TITLE
Signing key param for prestage enabled prompts

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,6 +14,7 @@ services:
       MYSQL_DATABASE: default_database
       MYSQL_USER: user
       MYSQL_PASS: password
+      PROMPT_SIGNING_KEY: default_signing_key
       JWT_TRUSTED_ISSUERS: '[{ "iss": "unified-auth", "url": "http://fakeauth/jwks" }]'
       JWT_TRUSTED_CLIENTIDS: reqquest
       RESET_DB_ON_STARTUP: 'true'

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -75,7 +75,7 @@
 {#key prompt.id}
   <div class="prompt-intro flow max-w-screen-md mx-auto pt-10 px-6">
     <!-- svelte-ignore a11y_autofocus -->
-    <h2 id="prompt-title" tabindex="-1" autofocus class="font-bold text-2xl leading-normal text-center">{prompt.title}</h2>
+    <h2 id="prompt-title" tabindex="-1" autofocus class="font-medium text-xl text-center">{prompt.title}</h2>
     <p class="text-center"> {prompt.description}</p>
   </div>
   <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>


### PR DESCRIPTION
Issue:

docker-compose.test.yml did not have required signing key env param, caused start to fail for any demo instance that has prestage prompts

Solution:

Added signing key env to test compose file