### PR TITLE
Present invalidated prompt details to applicant on Prompt page and in Nav

### DIFF
--- a/api/src/appRequest/appRequest.resolver.ts
+++ b/api/src/appRequest/appRequest.resolver.ts
@@ -80,7 +80,7 @@ export class AppRequestResolver {
   async updatePrompt (@Ctx() ctx: RQContext, @Arg('promptId', type => ID) promptId: string, @Arg('data', type => JsonData) data: any, @Arg('validateOnly', { nullable: true }) validateOnly?: boolean, @Arg('dataVersion', type => Int, { nullable: true, description: 'The data version of the app request at the time this prompt was loaded. If provided, the API will perform an optimistic concurrency check and fail the update if someone else has updated the data in the meantime.' }) dataVersion?: number, @Arg('overrideInvalidated', { nullable: true }) overrideInvalidated?: boolean) {
     const prompt = await ctx.svc(RequirementPromptService).findById(promptId)
     if (!prompt) throw new Error('Prompt not found.')
-    return await ctx.svc(RequirementPromptService).update(prompt, data, validateOnly, dataVersion)
+    return await ctx.svc(RequirementPromptService).update(prompt, data, validateOnly, dataVersion, overrideInvalidated)
   }
 
   @Mutation(returns => ValidatedAppRequestResponse, { description: 'Create a new app request.' })

--- a/api/src/appRequest/appRequest.resolver.ts
+++ b/api/src/appRequest/appRequest.resolver.ts
@@ -77,7 +77,7 @@ export class AppRequestResolver {
   }
 
   @Mutation(returns => ValidatedAppRequestResponse, { description: 'Update the data for a prompt in this app request.' })
-  async updatePrompt (@Ctx() ctx: RQContext, @Arg('promptId', type => ID) promptId: string, @Arg('data', type => JsonData) data: any, @Arg('validateOnly', { nullable: true }) validateOnly?: boolean, @Arg('dataVersion', type => Int, { nullable: true, description: 'The data version of the app request at the time this prompt was loaded. If provided, the API will perform an optimistic concurrency check and fail the update if someone else has updated the data in the meantime.' }) dataVersion?: number) {
+  async updatePrompt (@Ctx() ctx: RQContext, @Arg('promptId', type => ID) promptId: string, @Arg('data', type => JsonData) data: any, @Arg('validateOnly', { nullable: true }) validateOnly?: boolean, @Arg('dataVersion', type => Int, { nullable: true, description: 'The data version of the app request at the time this prompt was loaded. If provided, the API will perform an optimistic concurrency check and fail the update if someone else has updated the data in the meantime.' }) dataVersion?: number, @Arg('overrideInvalidated', { nullable: true }) overrideInvalidated?: boolean) {
     const prompt = await ctx.svc(RequirementPromptService).findById(promptId)
     if (!prompt) throw new Error('Prompt not found.')
     return await ctx.svc(RequirementPromptService).update(prompt, data, validateOnly, dataVersion)

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -287,7 +287,7 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
     return newPrompt
   }
 
-  async update (prompt: RequirementPrompt, data: any, validateOnly = false, dataVersion?: number) {
+  async update (prompt: RequirementPrompt, data: any, validateOnly = false, dataVersion?: number, overrideInvalidated?: boolean) {
     data ??= {}
     if (!this.mayUpdate(prompt)) throw new Error('You are not allowed to update this prompt.')
     if ((PROMPT_PRESTAGE_NS in data) && !await this.verifyPrestageData(prompt.appRequestInternalId, prompt.key, data[PROMPT_PRESTAGE_NS], dataVersion)) throw new Error('Invalid prompt signed data.')
@@ -323,6 +323,7 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
         const promptsToInvalidate = promptRegistry.getInvalidatedPrompts(prompt.key, appRequestData, allConfigData)
         await setRequirementPromptsInvalid(promptsToInvalidate, db)
         const promptsToRevalidate = promptRegistry.getRevalidatedPrompts(prompt.key, appRequestData, allConfigData)
+        if (prompt.invalidated && overrideInvalidated) promptsToRevalidate.push(prompt.key) // used as a positive confirmation that this previously invalidated prompt requires no changes to be valid again
         await setRequirementPromptsValid(promptsToRevalidate.concat([prompt.key]), db)
         previousAppPhases = (await updateAppRequestData(appRequest.internalId, appRequestData, dataVersion, db))!
         recordAppRequestActivity(appRequest.internalId, this.user!.internalId, `${programRegistry.get(prompt.programKey)?.navTitle ?? 'Prompt'} Updated`, { data, description: prompt.title, impersonatedBy: this.impersonationUser?.internalId }, db)

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -315,7 +315,7 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
       }
       if (validateOnly) return
       response.success = true // if we got this far, it's saving the data, so that's a success even if the data isn't quite valid yet
-      if (!equal(appRequestData[prompt.key], processedData)) {
+      if (!equal(appRequestData[prompt.key], processedData) || (prompt.invalidated && overrideInvalidated)) {
         updated = true
         previousAppRequestStatus = appRequest.status
         savedData = appRequestData[prompt.key]

--- a/demos/src/complex/definitions/models/residence.models.ts
+++ b/demos/src/complex/definitions/models/residence.models.ts
@@ -106,8 +106,7 @@ export const ReviewStateResidenceInfoPromptSchema = {
   type: 'object',
   properties: {
     residencyInfoAcceptable: { type: 'boolean' },
-    corrections: { type: 'string' },
-    lastReviewedAt: { type: 'number' }
+    corrections: { type: 'string' }
   },
   additionalProperties: false
 } as const satisfies SchemaObject

--- a/demos/src/complex/definitions/models/residence.models.ts
+++ b/demos/src/complex/definitions/models/residence.models.ts
@@ -106,7 +106,8 @@ export const ReviewStateResidenceInfoPromptSchema = {
   type: 'object',
   properties: {
     residencyInfoAcceptable: { type: 'boolean' },
-    corrections: { type: 'string' }
+    corrections: { type: 'string' },
+    lastReviewedAt: { type: 'number' }
   },
   additionalProperties: false
 } as const satisfies SchemaObject

--- a/demos/src/complex/definitions/prompts/residence.prompts.ts
+++ b/demos/src/complex/definitions/prompts/residence.prompts.ts
@@ -62,7 +62,7 @@ export const review_applicant_state_residence_info_prompt: PromptDefinition = {
     if (!data) messages.push({ type: MutationMessageType.error, message: 'Confirmation info required' })
     if (data.residencyInfoAcceptable == null) messages.push({ type: MutationMessageType.error, message: 'Confirmation of residency required', arg: 'residencyInfoAcceptable' })
     if (!data.residencyInfoAcceptable) {
-      if (!data.corrections) messages.push({ type: MutationMessageType.error, message: 'Suggested corrections required', arg: 'corrections' })
+      if (!data.corrections) messages.push({ type: MutationMessageType.error, message: 'Suggested corrections needed', arg: 'corrections' })
     }
     return messages
   },

--- a/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
+++ b/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
@@ -25,7 +25,8 @@ export const technical_troubleshooting_prompt: PromptDefinition<TechincalTrouble
     if (data.describeTechincalTroubleshooting == null) messages.push({ type: MutationMessageType.error, message: 'This field is required', arg: 'describeTechincalTroubleshooting' })
 
     return messages
-  }
+  },
+  invalidUponChange: [{ promptKey: 'assess_technical_troubleshooting_prompt' }]
 }
 
 export const assess_technical_troubleshooting_prompt: PromptDefinition<AssessTechincalTroubleshootingData> = {
@@ -39,7 +40,8 @@ export const assess_technical_troubleshooting_prompt: PromptDefinition<AssessTec
     if (data.demonstrateTechincalTroubleshooting == null) messages.push({ type: MutationMessageType.error, message: 'This field is required', arg: '.demonstrateTechincalTroubleshooting' })
 
     return messages
-  }
+  },
+  invalidUponChange: [{ promptKey: 'technical_troubleshooting_prompt', reason: 'Troubleshooting was poorly described, make changes and resubmit' }]
 }
 
 export const support_communication_prompt: PromptDefinition<SupportCommunicationData> = {

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -256,7 +256,9 @@ class API extends APIBase {
               prestageData: true,
               fetchedData: true,
               configurationData: true,
-              gatheredConfigData: true
+              gatheredConfigData: true,
+              invalidated: true,
+              invalidatedReason: true
         }
       }
     }) 

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -281,28 +281,10 @@ class API extends APIBase {
     return this.mutationForDialog(response.stagePrompt)
   }
 
-  /* TODO: Future require to support staging prompts in bulk for supporting review data
-  async stagePrompts (promptIds: string[], dataVersion?: number) {
-    const response = await this.graphqlWithUploads<{ stagePrompt: MutationResponseFromAPI }>(`
-      mutation StagePrompts($promptIds: [ID!]!, $dataVersion: Int) {
-        stagePrompt(promptIds: $promptIds, dataVersion: $dataVersion) {
-          success
-          messages {
-            message
-            type
-            arg
-          }
-        }
-      }
-    `, { promptIds, dataVersion })
-    return this.mutationForDialog(response.stagePrompt)
-  }
-  */
-
   async updatePrompt (promptId: string, data: any, validateOnly: boolean, dataVersion?: number, overrideInvalidated?: boolean) {
     const response = await this.graphqlWithUploads<{ updatePrompt: MutationResponseFromAPI }>(`
-      mutation UpdatePrompt($promptId: ID!, $data: JsonData!, $validateOnly: Boolean!, $dataVersion: Int) {
-        updatePrompt(promptId: $promptId, data: $data, validateOnly: $validateOnly, dataVersion: $dataVersion) {
+      mutation UpdatePrompt($promptId: ID!, $data: JsonData!, $validateOnly: Boolean!, $dataVersion: Int, $overrideInvalidated: Boolean) {
+        updatePrompt(promptId: $promptId, data: $data, validateOnly: $validateOnly, dataVersion: $dataVersion, overrideInvalidated: $overrideInvalidated) {
           success
           messages {
             message

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -299,7 +299,7 @@ class API extends APIBase {
   }
   */
 
-  async updatePrompt (promptId: string, data: any, validateOnly: boolean, dataVersion?: number) {
+  async updatePrompt (promptId: string, data: any, validateOnly: boolean, dataVersion?: number, overrideInvalidated?: boolean) {
     const response = await this.graphqlWithUploads<{ updatePrompt: MutationResponseFromAPI }>(`
       mutation UpdatePrompt($promptId: ID!, $data: JsonData!, $validateOnly: Boolean!, $dataVersion: Int) {
         updatePrompt(promptId: $promptId, data: $data, validateOnly: $validateOnly, dataVersion: $dataVersion) {
@@ -314,7 +314,7 @@ class API extends APIBase {
           }
         }
       }
-    `, { promptId, data, validateOnly, dataVersion })
+    `, { promptId, data, validateOnly, dataVersion, overrideInvalidated })
     return { ...this.mutationForDialog(response.updatePrompt), data: response.updatePrompt.appRequest.data }
   }
 

--- a/ui/src/internal/components/ApplicantOptOutModal.svelte
+++ b/ui/src/internal/components/ApplicantOptOutModal.svelte
@@ -60,6 +60,7 @@
   on:cancel={() => { open = false }}
   on:validate={onValidate}
   on:saved={saved}
+  disableSaveUntilChanged={true}
   {submit}
   title={`${optIn ? 'Opt in to' : 'Opt out of'} ${optOutSelected?.title}?`}
   submitText={optIn ? 'Opt in' : 'Opt out'}
@@ -67,5 +68,5 @@
   preload={prompt.preloadData}
   preloadAsDraft={!prompt.hasSavedData} 
   >
-    <svelte:component this={def!.formComponent} {data} appRequestId={appRequest.id} appRequestData={appRequest.data} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
+    <svelte:component this={def!.formComponent} {data} appRequestId={appRequest.id} appRequestData={appRequest.data} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
 </PanelFormDialog>

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -79,7 +79,7 @@
     <p class="text-center"> {prompt.description}</p>
   </div>
   <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
-    <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} prestageData={{latest: prompt.prestageData, current: appRequestForExport.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
+    <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} prestageData={{latest: prompt.prestageData, current: appRequestForExport.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData}  invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
     <svelte:fragment slot="submit" let:submitting>
       <div class='form-submit flex gap-12 justify-center mt-16'>
         {#if hasPreviousPrompt}

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -8,7 +8,7 @@
 
   import { Form } from '@txstate-mws/carbon-svelte'
   import type { FormStore } from '@txstate-mws/svelte-forms'
-  import { Button } from 'carbon-components-svelte'
+  import { Button, InlineNotification } from 'carbon-components-svelte'
   import { getContext } from 'svelte'
   import type { Writable } from 'svelte/store'
   import { afterNavigate, beforeNavigate, goto, invalidate, invalidateAll } from '$app/navigation'
@@ -89,5 +89,18 @@
         <Button icon={submitting && !continueAfterSave ? ButtonLoadingIcon : null} type="submit" disabled={submitting} on:click={() => { continueAfterSave = true }}>Continue</Button>
       </div>
     </svelte:fragment>
+    <div class="flow max-w-screen-md">
+    <!-- Correction inline prompt notification -->
+    {#if prompt.invalidated && !$store?.hasUnsavedChanges}
+      <InlineNotification
+        kind="error"
+        title='Corrections required:'
+        hideCloseButton={true}
+        lowContrast
+        subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}
+      />
+    {/if}
+  </div>
   </Form>
+  
 {/key}

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -6,7 +6,7 @@
    * the app request since the prompt should only be visible in a single spot.
    */
 
-  import { Form } from '@txstate-mws/carbon-svelte'
+  import { Form, confirmationStore } from '@txstate-mws/carbon-svelte'
   import type { FormStore } from '@txstate-mws/svelte-forms'
   import { Button, InlineNotification } from 'carbon-components-svelte'
   import { getContext } from 'svelte'
@@ -39,7 +39,7 @@
 
  async function onSubmit (data: any) {
     loading = true    
-    const { success, messages, data: newData } =  await api.updatePrompt(prompt.id, data, false, dataVersion)
+    const { success, messages, data: newData } =  await api.updatePrompt(prompt.id, data, false, dataVersion, await confirmInvalidatedOverride())
     if (!success) loading = false
     return {
       success,
@@ -60,6 +60,19 @@
       await goto($nextHref.nextHref)
     }
     loading = false
+  }
+
+  async function confirmInvalidatedOverride() {
+   return (prompt.invalidated && $store?.hasUnsavedChanges) 
+    ? await confirmationStore.confirm(
+        'Corrections are required, but no changes have been made.  Can you confirm that all data is correct, and does not require changes?',
+        {
+          title: 'Confirm data is correct',
+          yesText: 'Yes',
+          noText: 'No'
+        }
+      )
+    : false 
   }
 
   let lastPromptId: string | undefined

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -38,7 +38,7 @@
   }
 
  async function onSubmit (data: any) {
-    loading = true    
+    loading = true   
     const { success, messages, data: newData } =  await api.updatePrompt(prompt.id, data, false, dataVersion, await confirmInvalidatedOverride())
     if (!success) loading = false
     return {
@@ -63,7 +63,7 @@
   }
 
   async function confirmInvalidatedOverride() {
-   return (prompt.invalidated && $store?.hasUnsavedChanges) 
+   return (prompt.invalidated && !$store?.hasUnsavedChanges) 
     ? await confirmationStore.confirm(
         'Corrections are required, but no changes have been made.  Can you confirm that all data is correct, and does not require changes?',
         {

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -90,17 +90,17 @@
       </div>
     </svelte:fragment>
     <div class="flow max-w-screen-md">
-    <!-- Correction inline prompt notification -->
-    {#if prompt.invalidated && !$store?.hasUnsavedChanges}
-      <InlineNotification
-        kind="error"
-        title='Corrections required:'
-        hideCloseButton={true}
-        lowContrast
-        subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}
-      />
-    {/if}
-  </div>
+      <!-- Correction inline prompt notification -->
+      {#if prompt.invalidated && !$store?.hasUnsavedChanges}
+        <InlineNotification
+          kind="error"
+          title='Corrections required:'
+          hideCloseButton={true}
+          lowContrast
+          subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}
+        />
+      {/if}
+    </div>
   </Form>
   
 {/key}

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -106,8 +106,8 @@
       <!-- Correction inline prompt notification -->
       {#if prompt.invalidated && !$store?.hasUnsavedChanges}
         <InlineNotification
-          kind="error"
-          title='Corrections required:'
+          kind="warning-alt"
+          title='Corrections needed:'
           hideCloseButton={true}
           lowContrast
           subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}

--- a/ui/src/internal/components/ApplicationDetailsView.svelte
+++ b/ui/src/internal/components/ApplicationDetailsView.svelte
@@ -157,7 +157,7 @@
                   {prompt.title}
                 </dt>
                 <dd class="prompt-answer flow" class:large={def?.displayMode === 'large'}>
-                  <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appData} prompt={prompt} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
+                  <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appData} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
                   {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
                     <Button kind="ghost" size="small" icon={Edit} iconDescription="Edit this answer" href={`/requests/${appRequest.id}/apply/${prompt.id}`} class="edit-button" />
                   {/if}
@@ -203,7 +203,7 @@
                       {prompt.title}
                     </dt>
                     <dd class="prompt-answer flow" class:large={def?.displayMode === 'large'}>
-                      <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appData} prompt={prompt} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
+                      <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appData} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
                       {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
                         <Button kind="ghost" size="small" icon={Edit} iconDescription="Edit this answer" href={`/requests/${appRequest.id}/apply/${prompt.id}`} class="edit-button" />
                       {/if}

--- a/ui/src/internal/components/ApplicationDetailsView.svelte
+++ b/ui/src/internal/components/ApplicationDetailsView.svelte
@@ -159,14 +159,12 @@
                 <dd class="prompt-answer flow" class:large={def?.displayMode === 'large'}>
                   <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appData} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
                   {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
-                    <Button kind="ghost" size="small" icon={Edit} iconDescription="Edit this answer" href={`/requests/${appRequest.id}/apply/${prompt.id}`} class="edit-button" />
+                    <div class="correction-notice">
+                      <Button kind="ghost" size="small" icon={Edit} iconDescription="Edit this answer" href={`/requests/${appRequest.id}/apply/${prompt.id}`} class="edit-button" />
+                      <InlineNotification kind="warning-alt" title="Corrections needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
+                    </div>
                   {/if}
                 </dd>
-                {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
-                  <div class="correction-notice">
-                    <InlineNotification kind="warning-alt" title="Corrections needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
-                  </div>
-                {/if}
               {/each}
             </dl>
           {/if}

--- a/ui/src/internal/components/ApplicationDetailsView.svelte
+++ b/ui/src/internal/components/ApplicationDetailsView.svelte
@@ -151,7 +151,7 @@
                       <div class="icon" slot="icon">
                         <WarningIconYellow size={16} />
                       </div>
-                      <p>Correction needed<br>{prompt.invalidatedReason}</p>
+                      <p>Corrections needed<br>{prompt.invalidatedReason}</p>
                     </Tooltip>
                   {/if}
                   {prompt.title}
@@ -164,7 +164,7 @@
                 </dd>
                 {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
                   <div class="correction-notice">
-                    <InlineNotification kind="warning-alt" title="Correction needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
+                    <InlineNotification kind="warning-alt" title="Corrections needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
                   </div>
                 {/if}
               {/each}
@@ -197,7 +197,7 @@
                           <div class="icon" slot="icon">
                             <WarningIconYellow size={16} />
                           </div>
-                          <p>Correction needed<br>{prompt.invalidatedReason}</p>
+                          <p>Corrections needed<br>{prompt.invalidatedReason}</p>
                         </Tooltip>
                       {/if}
                       {prompt.title}
@@ -210,7 +210,7 @@
                     </dd>
                     {#if showCorrectionsInline && canMakeCorrections && needsCorrection(prompt)}
                       <div class="correction-notice">
-                        <InlineNotification kind="warning-alt" title="Correction needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
+                        <InlineNotification kind="warning-alt" title="Corrections needed" subtitle={prompt.invalidatedReason ?? ''} hideCloseButton lowContrast />
                       </div>
                     {/if}
                   {/each}

--- a/ui/src/internal/components/RenderDisplayComponent.svelte
+++ b/ui/src/internal/components/RenderDisplayComponent.svelte
@@ -10,6 +10,8 @@
   export let configData: Record<string, any>
   export let gatheredConfigData: Record<string, any>
   export let showMoot = false
+  export let showInlineReviewNotification = false 
+
 </script>
 
 <svelte:boundary onerror={e => console.error(e)}>
@@ -23,7 +25,7 @@
   {:else}
     <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
   {/if}
-  {#if prompt.invalidated && (showMoot || !prompt.moot)}
+  {#if prompt.invalidated && (showMoot || !prompt.moot) && showInlineReviewNotification}
     <InlineNotification class="mt-6 lg:mt-4" kind="warning" title="Applicant has made corrections:" subtitle={prompt.invalidatedReason ?? 'Requires review'} lowContrast hideCloseButton />
   {/if}
   {#snippet failed()}

--- a/ui/src/internal/components/RenderDisplayComponent.svelte
+++ b/ui/src/internal/components/RenderDisplayComponent.svelte
@@ -23,9 +23,9 @@
   {:else}
     <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} />
   {/if}
-  {#if prompt.invalidated && (showMoot || !prompt.moot)}
-    <InlineNotification kind="warning" title="Correction Needed" subtitle={prompt.invalidatedReason ?? undefined} class="mt-2" lowContrast hideCloseButton />
-  {/if}
+  <!--{#if prompt.invalidated && (showMoot || !prompt.moot)}
+    <InlineNotification kind="warning" title="Corrections Needed" subtitle={prompt.invalidatedReason ?? undefined} class="mt-2" lowContrast hideCloseButton />
+  {/if}-->
   {#snippet failed()}
     <div class="error">
       <div>Error Loading Component</div>

--- a/ui/src/internal/components/RenderDisplayComponent.svelte
+++ b/ui/src/internal/components/RenderDisplayComponent.svelte
@@ -21,7 +21,10 @@
     <em>No display component registered.</em>
     <pre>{JSON.stringify(appData[prompt.key] ?? {}, null, 2)}</pre>
   {:else}
-    <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} />
+    <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
+  {/if}
+  {#if prompt.invalidated && (showMoot || !prompt.moot)}
+    <InlineNotification class="mt-6 lg:mt-4 max-w-0" kind="warning" title="Applicant has made corrections:" subtitle={prompt.invalidatedReason ?? 'Requires review'} lowContrast hideCloseButton />
   {/if}
   {#snippet failed()}
     <div class="error">

--- a/ui/src/internal/components/RenderDisplayComponent.svelte
+++ b/ui/src/internal/components/RenderDisplayComponent.svelte
@@ -23,9 +23,6 @@
   {:else}
     <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} />
   {/if}
-  <!--{#if prompt.invalidated && (showMoot || !prompt.moot)}
-    <InlineNotification kind="warning" title="Corrections Needed" subtitle={prompt.invalidatedReason ?? undefined} class="mt-2" lowContrast hideCloseButton />
-  {/if}-->
   {#snippet failed()}
     <div class="error">
       <div>Error Loading Component</div>

--- a/ui/src/internal/components/RenderDisplayComponent.svelte
+++ b/ui/src/internal/components/RenderDisplayComponent.svelte
@@ -24,7 +24,7 @@
     <svelte:component this={def.displayComponent} {appRequestId} data={appData[prompt.key]} appRequestData={appData} {prestageData} {configData} {gatheredConfigData} invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
   {/if}
   {#if prompt.invalidated && (showMoot || !prompt.moot)}
-    <InlineNotification class="mt-6 lg:mt-4 max-w-0" kind="warning" title="Applicant has made corrections:" subtitle={prompt.invalidatedReason ?? 'Requires review'} lowContrast hideCloseButton />
+    <InlineNotification class="mt-6 lg:mt-4" kind="warning" title="Applicant has made corrections:" subtitle={prompt.invalidatedReason ?? 'Requires review'} lowContrast hideCloseButton />
   {/if}
   {#snippet failed()}
     <div class="error">

--- a/ui/src/lib/typed-client/schema.graphql
+++ b/ui/src/lib/typed-client/schema.graphql
@@ -1306,6 +1306,7 @@ type Mutation {
     The data version of the app request at the time this prompt was loaded. If provided, the API will perform an optimistic concurrency check and fail the update if someone else has updated the data in the meantime.
     """
     dataVersion: Int
+    overrideInvalidated: Boolean
     promptId: ID!
     validateOnly: Boolean
   ): ValidatedAppRequestResponse!

--- a/ui/src/lib/typed-client/schema.ts
+++ b/ui/src/lib/typed-client/schema.ts
@@ -1533,7 +1533,7 @@ export interface MutationGenqlSelection{
     /** Update the data for a prompt in this app request. */
     updatePrompt?: (ValidatedAppRequestResponseGenqlSelection & { __args: {data: Scalars['JsonData'], 
     /** The data version of the app request at the time this prompt was loaded. If provided, the API will perform an optimistic concurrency check and fail the update if someone else has updated the data in the meantime. */
-    dataVersion?: (Scalars['Int'] | null), promptId: Scalars['ID'], validateOnly?: (Scalars['Boolean'] | null)} })
+    dataVersion?: (Scalars['Int'] | null), overrideInvalidated?: (Scalars['Boolean'] | null), promptId: Scalars['ID'], validateOnly?: (Scalars['Boolean'] | null)} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }

--- a/ui/src/lib/typed-client/types.ts
+++ b/ui/src/lib/typed-client/types.ts
@@ -1483,6 +1483,9 @@ export default {
                     "dataVersion": [
                         53
                     ],
+                    "overrideInvalidated": [
+                        41
+                    ],
                     "promptId": [
                         49,
                         "ID!"

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -13,6 +13,7 @@ export interface AnsweredPrompt {
   moot: boolean | null
   visibility: string
   optOut?: boolean | null
+  prestageData: Record<string, any>
   configurationData: Record<string, any>
   gatheredConfigData: Record<string, any>
   statusReasons: {

--- a/ui/src/local/complex/optional/ReviewMovieLoverDisplayPrompt.svelte
+++ b/ui/src/local/complex/optional/ReviewMovieLoverDisplayPrompt.svelte
@@ -2,4 +2,4 @@
   export let data
 </script>
 
-Movie knowledge is {!data.impressed ? 'un' : ''}impressive.<br>
+Movie knowledge is {!data?.impressed ? 'un' : ''}impressive.<br>

--- a/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPrompt.svelte
+++ b/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPrompt.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-  import { FieldRadio, FieldTextArea } from '@txstate-mws/carbon-svelte'
+  import { FieldRadio, FieldTextArea, FieldNumber } from '@txstate-mws/carbon-svelte'
   export let data
+  export let invalidated
+  data.residencyInfoAcceptable = (invalidated) ? undefined : data.residencyInfoAcceptable
+  data.lastReviewedAt = (invalidated) ? Date.now() : data.lastReviewedAt 
 </script>
 
 <FieldRadio boolean path="residencyInfoAcceptable" labelText="Does the ID file match applicant input?" items={
@@ -9,5 +12,12 @@
     { value: false, label: 'No' }    
   ]
 } />
+
+<span class="hidden">
+  <FieldNumber
+      path="lastReviewedAt"
+      defaultValue={Date.now()}
+    />
+</span>
 
 <FieldTextArea path="corrections" conditional={ data.residencyInfoAcceptable === false } labelText="Identify inaccuracies between ID file and applicant input" />

--- a/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPrompt.svelte
+++ b/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPrompt.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { FieldRadio, FieldTextArea, FieldNumber } from '@txstate-mws/carbon-svelte'
   export let data
-  export let invalidated
-  data.residencyInfoAcceptable = (invalidated) ? undefined : data.residencyInfoAcceptable
-  data.lastReviewedAt = (invalidated) ? Date.now() : data.lastReviewedAt 
 </script>
 
 <FieldRadio boolean path="residencyInfoAcceptable" labelText="Does the ID file match applicant input?" items={
@@ -12,12 +9,5 @@
     { value: false, label: 'No' }    
   ]
 } />
-
-<span class="hidden">
-  <FieldNumber
-      path="lastReviewedAt"
-      defaultValue={Date.now()}
-    />
-</span>
 
 <FieldTextArea path="corrections" conditional={ data.residencyInfoAcceptable === false } labelText="Identify inaccuracies between ID file and applicant input" />

--- a/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPromptDisplay.svelte
+++ b/ui/src/local/complex/residence/ReviewApplicantResidenceInfoPromptDisplay.svelte
@@ -2,8 +2,10 @@
   export let data
 </script>
 
+
 Residency info { !data.residencyInfoAcceptable ? 'does not match ' : 'matches ' }ID file.
 {#if !data.residencyInfoAcceptable}
-  <br><b>Suggested issues or corrections</b>: { data.corrections }
+  <br><b>Suggested corrections</b>: { data.corrections }
 {/if}
+
 

--- a/ui/src/routes/requests/[id]/apply/+layout.svelte
+++ b/ui/src/routes/requests/[id]/apply/+layout.svelte
@@ -31,8 +31,12 @@
         label: prompt.navTitle,
         href: resolve(`/requests/${appRequestForExport.id}/apply/${prompt.id}`),
         type: $page.params.promptId === prompt.id
-          ? 'current'
-          : prompt.answered && !prompt.invalidated ? 'complete' : 'available',
+          ? 'current'          
+          : prompt.answered && !prompt.invalidated
+            ? 'complete' 
+            : prompt.answered && prompt.invalidated
+              ? 'warning'
+              : 'available',
         substeps: []
       })
     }
@@ -93,8 +97,12 @@
               label: prompt.navTitle,
               href: resolve(`/requests/${appRequestForExport.id}/apply/${prompt.id}`),
               type: $page.params.promptId === prompt.id
-                ? 'current'
-                : prompt.answered && !prompt.invalidated ? 'complete' : 'available'
+                ? 'current'          
+                : prompt.answered && !prompt.invalidated
+                  ? 'complete' 
+                  : prompt.answered && prompt.invalidated
+                    ? 'warning'
+                    : 'available'
             })
           }
         }
@@ -103,16 +111,18 @@
           nextHref = resolve(`/requests/${appRequestForExport.id}/apply/programs`)
           foundCurrent = false
         }
-        if (substeps.length > 0) {
+       if (substeps.length > 0) {
           navItems.push({
             id: `application${application.id}`,
             label: application.navTitle,
             href: substeps[0].href,
-            type: substeps.some(s => s.type === 'current')
-              ? 'current'
-              : substeps.every(s => s.type === 'complete')
-                ? 'complete'
-                : 'available',
+            type: substeps.some(s => s.type === 'warning')
+              ? 'warning'
+              : substeps.some(s => s.type === 'current')
+                ? 'current'
+                : substeps.every(s => s.type === 'complete')
+                  ? 'complete'
+                  : 'available',
             substeps
           })
         }

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -195,13 +195,13 @@
   let promptBeingEdited: PromptWithExtra | undefined = undefined
   let showPromptDialog = false
   let fetchingEditPrompt = false
-  function editPrompt (prompt: Prompt) {
+  function editPrompt (prompt: Prompt, allowSaveWithoutChanges: boolean = false) {
     return async () => {
       if (fetchingEditPrompt) return
       fetchingEditPrompt = true
       try {
         const extra = await api.getPromptData(appRequest.id, prompt.id)
-        promptBeingEdited = { ...prompt, ...extra }
+        promptBeingEdited = { ...prompt, ...extra, allowSaveWithoutChanges }
         showPromptDialog = true
       } finally {
         fetchingEditPrompt = false
@@ -224,7 +224,9 @@
     return async (data: any) => {   
       loading = true      
       hideEditModalPromptOnLoading()  
-      const response = await api.updatePrompt(prompt.id, data, false)
+      const response = (!prompt.allowSaveWithoutChanges)
+        ? await api.updatePrompt(prompt.id, data, false)
+        : await api.updatePrompt(prompt.id, data, false, undefined, true) // triggers from review corrections edit selection, allow saving without changes to handle invalidate prompts that require no changes
       return response
     }
   }
@@ -372,7 +374,7 @@
                   <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                   {#if prompt.actions.update}
                     {#if prompt.invalidated && !applicantRequirementTypes.has(requirement.type)}
-                      <Button kind="primary" size="field" class="prompt-edit mr-2" icon={Review} iconDescription="Review corrections" on:click={editPrompt(prompt)} />
+                      <Button kind="primary" size="field" class="prompt-edit mr-2" icon={Review} iconDescription="Review corrections" on:click={editPrompt(prompt, true)} />
                     {:else}
                       <Button kind="ghost" size="field" icon={Edit} iconDescription="Edit Prompt" class="prompt-edit" on:click={editPrompt(prompt)} />
                     {/if}
@@ -414,7 +416,7 @@
     submit={onPromptSubmit(promptBeingEdited)}
     validate={onPromptValidate(promptBeingEdited)}
     on:saved={onPromptSaved}
-    disableSaveUntilChanged={!promptBeingEdited.invalidated} // allow saving without changes if prompt was previously invalidated ...accomodates reviewer saying no changes required on correction check
+    disableSaveUntilChanged={!promptBeingEdited.allowSaveWithoutChanges} // allow saving without changes if prompt was previously invalidated ...accomodates reviewer saying no changes required on correction check
     centered
     preload={promptBeingEdited.preloadData}
     let:data

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -370,14 +370,17 @@
                       <FormInlineNotification {message} />
                     {/each}
                   </Form>
-                {:else}
-                  <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
+                {:else} 
                   {#if prompt.actions.update}
                     {#if prompt.invalidated && !applicantRequirementTypes.has(requirement.type)}
+                      <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot showInlineReviewNotification={true} />
                       <Button kind="primary" size="field" class="prompt-edit mr-2" icon={Review} iconDescription="Review corrections" on:click={editPrompt(prompt, true)} />
                     {:else}
+                      <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                       <Button kind="ghost" size="field" icon={Edit} iconDescription="Edit Prompt" class="prompt-edit" on:click={editPrompt(prompt)} />
-                    {/if}
+                    {/if}     
+                    {:else}
+                      <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                   {/if}
                 {/if}
               </dd>

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -371,7 +371,7 @@
                   <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                   {#if prompt.actions.update}
                     {#if prompt.invalidated && !applicantRequirementTypes.has(requirement.type)}
-                      <Button kind="primary" size="field" class="prompt-edit" on:click={editPrompt(prompt)}>Review correction</Button>
+                      <Button kind="primary" size="field" class="flex prompt-edit mr-2 mt-2" on:click={editPrompt(prompt)}>Review corrections</Button>
                     {:else}
                       <Button kind="ghost" size="field" icon={Edit} iconDescription="Edit Prompt" class="prompt-edit" on:click={editPrompt(prompt)} />
                     {/if}

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -220,11 +220,11 @@
     promptBeingEdited = undefined
   }
 
-  function onPromptSubmit (id: string) {
+  function onPromptSubmit (prompt: any) {
     return async (data: any) => {   
       loading = true      
       hideEditModalPromptOnLoading()  
-      const response = await api.updatePrompt(id, data, false)
+      const response = await api.updatePrompt(prompt.id, data, false)
       return response
     }
   }
@@ -362,7 +362,7 @@
               </dt>
               <dd class="flow" class:small class:large class:isReviewerQuestion class:bg-tagyellow-200={isAutomation} role={editMode ? 'group' : undefined} aria-labelledby={dtid}>
                 {#if editMode}
-                  <Form preload={prompt.preloadData} submit={onPromptSubmit(prompt.id)} validate={onPromptValidate(prompt)} autoSave on:autosaved={onPromptSaved} let:data let:messages>
+                  <Form preload={prompt.preloadData} submit={onPromptSubmit(prompt)} validate={onPromptValidate(prompt)} autoSave on:autosaved={onPromptSaved} let:data let:messages>
                     <svelte:component this={def.formComponent} {data} appRequestData={appRequest.data} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData}  invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason}  />
                     {#each messages as message (message.message, message.type)}
                       <FormInlineNotification {message} />
@@ -411,10 +411,10 @@
     title={promptBeingEdited.invalidated ? `Review correction "${promptBeingEdited.title}"` : 'Edit Prompt'}
     bind:open={showPromptDialog}
     on:cancel={closePromptDialog}
-    submit={onPromptSubmit(promptBeingEdited.id)}
+    submit={onPromptSubmit(promptBeingEdited)}
     validate={onPromptValidate(promptBeingEdited)}
     on:saved={onPromptSaved}
-    disableSaveUntilChanged={true}
+    disableSaveUntilChanged={!promptBeingEdited.invalidated} // allow saving without changes if prompt was previously invalidated ...accomodates reviewer saying no changes required on correction check
     centered
     preload={promptBeingEdited.preloadData}
     let:data

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -370,8 +370,9 @@
                 {:else}
                   <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                   {#if prompt.actions.update}
+                  {console.log(requirement)}
                     {#if prompt.invalidated && !applicantRequirementTypes.has(requirement.type)}
-                      <Button kind="primary" size="field" class="flex prompt-edit mr-2 mt-2" on:click={editPrompt(prompt)}>Review corrections</Button>
+                      <Button kind="primary" size="field" class="prompt-edit mr-2 mt-2" on:click={editPrompt(prompt)}>Review corrections</Button>
                     {:else}
                       <Button kind="ghost" size="field" icon={Edit} iconDescription="Edit Prompt" class="prompt-edit" on:click={editPrompt(prompt)} />
                     {/if}

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -5,6 +5,7 @@
   import { Button, InlineNotification, Select, SelectItem, Tooltip } from 'carbon-components-svelte'
   import DocumentExport from 'carbon-icons-svelte/lib/DocumentExport.svelte'
   import Edit from 'carbon-icons-svelte/lib/Edit.svelte'
+  import Review from "carbon-icons-svelte/lib/Review.svelte";
   import MachineLearning from 'carbon-icons-svelte/lib/MachineLearning.svelte'
   import Pen from 'carbon-icons-svelte/lib/Pen.svelte'
   import TrashCan from 'carbon-icons-svelte/lib/TrashCan.svelte'
@@ -362,7 +363,7 @@
               <dd class="flow" class:small class:large class:isReviewerQuestion class:bg-tagyellow-200={isAutomation} role={editMode ? 'group' : undefined} aria-labelledby={dtid}>
                 {#if editMode}
                   <Form preload={prompt.preloadData} submit={onPromptSubmit(prompt.id)} validate={onPromptValidate(prompt)} autoSave on:autosaved={onPromptSaved} let:data let:messages>
-                    <svelte:component this={def.formComponent} {data} appRequestData={appRequest.data} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} />
+                    <svelte:component this={def.formComponent} {data} appRequestData={appRequest.data} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData}  invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason}  />
                     {#each messages as message (message.message, message.type)}
                       <FormInlineNotification {message} />
                     {/each}
@@ -370,9 +371,8 @@
                 {:else}
                   <RenderDisplayComponent {def} appRequestId={appRequest.id} appData={appRequest.data} prompt={prompt} prestageData={{latest: prompt.prestageData, current: appRequest.data[prompt.key]?.__prestage}} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData} showMoot />
                   {#if prompt.actions.update}
-                  {console.log(requirement)}
                     {#if prompt.invalidated && !applicantRequirementTypes.has(requirement.type)}
-                      <Button kind="primary" size="field" class="prompt-edit mr-2 mt-2" on:click={editPrompt(prompt)}>Review corrections</Button>
+                      <Button kind="primary" size="field" class="prompt-edit mr-2" icon={Review} iconDescription="Review corrections" on:click={editPrompt(prompt)} />
                     {:else}
                       <Button kind="ghost" size="field" icon={Edit} iconDescription="Edit Prompt" class="prompt-edit" on:click={editPrompt(prompt)} />
                     {/if}
@@ -423,7 +423,7 @@
     <div class='font-medium text-center mt-2'>
       <p class="text-xl font-medium ">{promptBeingEdited.title}</p>
     </div>
-    <svelte:component this={def!.formComponent} appRequestId={appRequest.id} {data} appRequestData={promptBeingEdited.data} prestageData={{latest: promptBeingEdited.prestageData, current: appRequest.data[promptBeingEdited.key]?.__prestage}} fetched={promptBeingEdited.fetchedData} configData={promptBeingEdited.configurationData} gatheredConfigData={promptBeingEdited.gatheredConfigData} />
+    <svelte:component this={def!.formComponent} appRequestId={appRequest.id} {data} appRequestData={promptBeingEdited.data} prestageData={{latest: promptBeingEdited.prestageData, current: appRequest.data[promptBeingEdited.key]?.__prestage}} fetched={promptBeingEdited.fetchedData} configData={promptBeingEdited.configurationData} gatheredConfigData={promptBeingEdited.gatheredConfigData} invalidated={promptBeingEdited.invalidated} invalidatedReason={promptBeingEdited.invalidatedReason} />
   </PanelFormDialog>
 {/if}
 


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/366
https://github.com/txstate-etc/reqquest-txstate/issues/367

Issue:

Currently invalidated applicant prompt pages do not provide detail on what is wrong on the prompt page, or any other reference to additional corrections when in the applicant nav view

Solution:

Applicant prompt pages now display the correction message as an InlineNotification within the applicant prompt form, similar to page level validation messages.  Additionally the Nav menu will now render warning icons for prompt pages that require additional corrections to make it easier for applicants to identify and not requiring toggling back and forth to their dashboard

* Appended ticket 367 work items to this PR as messages displayed to reviewers from applicant side are included