### PR TITLE
Reorder tooltip reasons to set precedent order of ineligible, warning, met

### DIFF
--- a/ui/src/internal/components/ApplicantProgramListTooltip.svelte
+++ b/ui/src/internal/components/ApplicantProgramListTooltip.svelte
@@ -6,13 +6,8 @@
 </script>
 
 {#if application.warningReasons.length || application.ineligibleReasons.length || application.metReasons.length}
-  <Tooltip align="end" direction="bottom" triggerText="" class="reason-tooltip">
-    {#if application.metReasons.length}
-      <p><strong>Eligible Because:</strong></p>
-      {#each application.metReasons as reason (reason)}
-        <p>{reason}</p>
-      {/each}
-    {:else if application.ineligibleReasons.length}
+  <Tooltip align="end" direction="bottom" triggerText="" class="reason-tooltip">    
+    {#if application.ineligibleReasons.length}
       <p><strong>Ineligible Because:</strong></p>
       {#each application.ineligibleReasons as reason (reason)}
         <p>{reason}</p>
@@ -22,6 +17,11 @@
       {#each application.warningReasons as reason (reason)}
         <p>{reason}</p>
       {/each}    
+    {:else if application.metReasons.length}
+       <p><strong>Eligible Because:</strong></p>
+      {#each application.metReasons as reason (reason)}
+        <p>{reason}</p>
+      {/each}
     {/if}
   </Tooltip>
 {/if}


### PR DESCRIPTION
Issue:

MET tooltips would supersede disqualifying (ineligible) tooltips if both were provide as reasons from their respective requirements

Solution:

Reorder tooltip precedence to ineligible, warning, met.