### PR TITLE
RQ-NEXT required build fix.  SMTP vars not included in test

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,6 +3,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      fakesmtp:
+        condition: service_started
     build:
       context: .
       dockerfile: demos/Dockerfile
@@ -15,6 +17,9 @@ services:
       MYSQL_USER: user
       MYSQL_PASS: password
       PROMPT_SIGNING_KEY: default_signing_key
+      PUBLISHED_BASE_URL: http://localhost
+      SMTP_SERVER: fakesmtp
+      SMTP_PORT: 1025
       JWT_TRUSTED_ISSUERS: '[{ "iss": "unified-auth", "url": "http://fakeauth/jwks" }]'
       JWT_TRUSTED_CLIENTIDS: reqquest
       RESET_DB_ON_STARTUP: 'true'
@@ -48,6 +53,8 @@ services:
         condition: service_healthy
       fakeauth:
         condition: service_healthy
+      fakesmtp:
+        condition: service_started
     build:
       context: .
       dockerfile: test/Dockerfile
@@ -65,6 +72,10 @@ services:
       interval: 2s
       timeout: 0.5s
       retries: 500
+  fakesmtp:
+    image: reachfive/fake-smtp-server:latest
+    ports:
+      - 127.0.0.1:1080:1080
   mysql:
     image: percona/percona-server:8.4
     attach: false

--- a/test/tests/all.bylogins.test.ts
+++ b/test/tests/all.bylogins.test.ts
@@ -16,6 +16,6 @@ test.describe('ByLogins admin flow', { tag: '@all' }, () => {
     expect(accessUsers).toHaveLength(1)
     expect(accessUsers[0].login).toEqual(uniqueAdmin)
     expect(accessUsers[0].fullname).toEqual(`${uniqueAdmin} Full Name`)
-    expect(accessUsers[0].otherInfo.email).toEqual(`${uniqueAdmin}@txstate.edu`)
+    expect(accessUsers[0].otherInfo.email).toEqual('reqquest-next@qual.txstate.edu')
   })
 })


### PR DESCRIPTION
Issue:
Automated test breaks because SMTP required env vars not included.

Solution:
Updated test compose to include vars.  One API test update also