### PR TITLE
PRE-SCHEDULE RELEASE: Reviewer PanelFormDialog set to large size when prompt defines mode as Full

### DIFF
--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.svelte
@@ -421,6 +421,7 @@
     on:saved={onPromptSaved}
     disableSaveUntilChanged={!promptBeingEdited.allowSaveWithoutChanges} // allow saving without changes if prompt was previously invalidated ...accomodates reviewer saying no changes required on correction check
     centered
+    size={uiRegistry.getPrompt(promptBeingEdited.key)?.formMode === 'full' ? 'large' : undefined}
     preload={promptBeingEdited.preloadData}
     let:data
   >


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/373
Issue:

Currently the reviewer PanelFormDialog is not setting larger display size when the prompt has defined a formMode of 'Full'

Fix:

PanelFormDialog `Size` property is now being set based on the in use prompts formMode definition