### PR TITLE
Extend UIRegistry to support applicantIntroPanel default slot config by RQ app dev

### DIFF
--- a/ui/src/lib/registry.ts
+++ b/ui/src/lib/registry.ts
@@ -190,8 +190,12 @@ export interface UIConfig {
      * This maps to the default slot available within the IntroPanel component and can be used
      * to add additional context within IntroPanel directly below the applicantDashboardIntroHeader and
      * applicantDashboardIntroDetail
+     * 
+     * It will receive the following props
+     * - `appRequests` with all appRequests and their details
+     * - `api` which is an instance of the API client
      */
-    applicantDashboardIntroSlot: Component
+    applicantDashboardIntroSlot?: Component
     /**
      * This will be placed inside the top card on the reviewer sidebar that displays applicant information.
      *
@@ -233,7 +237,7 @@ export class UIRegistry {
     for (const prompt of config.prompts) this.promptMap[prompt.key] = prompt
     for (const requirement of config.requirements) this.requirementMap[requirement.key] = requirement
     for (const program of config.programs) this.programMap[program.key] = program
-    this.userLookup = config.userLookup    
+    this.userLookup = config.userLookup 
     this.lang = {
       appRequest: config.terminology?.appRequest ?? (config.programs.length > 1 ? 'App Request' : 'Application'),
       login: config.terminology?.login ?? 'Login',

--- a/ui/src/lib/registry.ts
+++ b/ui/src/lib/registry.ts
@@ -187,6 +187,12 @@ export interface UIConfig {
    */
   slots?: {
     /**
+     * This maps to the default slot available within the IntroPanel component and can be used
+     * to add additional context within IntroPanel directly below the applicantDashboardIntroHeader and
+     * applicantDashboardIntroDetail
+     */
+    applicantDashboardIntroSlot: Component
+    /**
      * This will be placed inside the top card on the reviewer sidebar that displays applicant information.
      *
      * It will receive receive the following props:

--- a/ui/src/local/default/IntroPanelDefaultSlot.svelte
+++ b/ui/src/local/default/IntroPanelDefaultSlot.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import Time from "carbon-icons-svelte/lib/Time.svelte";
+</script>
+
+<span class="flex no-wrap pt-4">
+  <Time />
+  <p class='pl-2 text-sm'>Estimated time to complete a request is 2-5 minutes</p>
+</span>

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -108,6 +108,8 @@ import ComplexAcceptFosterPetPrompt from './complex/petOwner/AcceptFosterPetProm
 import ComplexAcceptFosterPetDisplayPrompt from './complex/petOwner/AcceptFosterPetDisplayPrompt.svelte'
 import ComplexConfirmCatMircochipServicePrompt from './complex/catOwner/ConfirmCatMircochipServicePrompt.svelte'
 import ComplexConfirmCatMircochipServiceDisplayPrompt from './complex/catOwner/ConfirmCatMircochipServiceDisplayPrompt.svelte'
+
+/** RC */
 import PreQualPrompt from './rc/PreQualPrompt.svelte'
 import WrittenAutomatinoPrompt from './rc/WrittenAutomatinoPrompt.svelte'
 import EvidenceWrittenAutomationPrompt from './rc/EvidenceWrittenAutomationPrompt.svelte'
@@ -158,10 +160,10 @@ import AssessReccomendationLetterDisplay from './rc/AssessReccomendationLetterDi
 import DataRelatedPuzzleDisplay from './rc/DataRelatedPuzzleDisplay.svelte'
 import OptOut from './rc/OptOut.svelte'
 import OptOutDisplay from './rc/OptOutDisplay.svelte'
+import RCIntroPanelDefaultSlot from './rc/IntroPanelDefaultSlot.svelte'
 import { api } from '$internal/api'
 
 
-/** RC */
 
 const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, programs, requirements, prompts, userLookup, slots } = configureDemoInstanceParams()
 
@@ -407,6 +409,9 @@ function configureDemoInstanceParams () {
       applicantDashboardIntroHeader: 'Apply for a technical mentorship here!',
       applicantDashboardIntroDetail: 'After applying for a mentorship, eligibilty will be determined based on your responses',
       applicantDashboardRecentDays: 30,
+      slots: {
+        applicantDashboardIntroSlot: RCIntroPanelDefaultSlot
+      },
       userLookup: async (login) => {
         const accessUser = await api.getAccessUser(login)
         if (!accessUser) return

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -23,6 +23,7 @@ import OtherCatsVaccinesPrompt from './default/OtherCatsVaccinesPrompt.svelte'
 import OtherCatsVaccinesPromptDisplay from './default/OtherCatsVaccinesPromptDisplay.svelte'
 import VaccineReviewPrompt from './default/VaccineReviewPrompt.svelte'
 import VaccineReviewPromptDisplay from './default/VaccineReviewPromptDisplay.svelte'
+import DefaultIntroPanelDefaultSlot from './default/IntroPanelDefaultSlot.svelte'
 
 /** simple */
 import ResidencePrompt from './simple/ResidencePrompt.svelte'
@@ -159,19 +160,21 @@ import OptOut from './rc/OptOut.svelte'
 import OptOutDisplay from './rc/OptOutDisplay.svelte'
 import { api } from '$internal/api'
 
+
 /** RC */
 
-const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, programs, requirements, prompts, userLookup } = configureDemoInstanceParams()
+const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, programs, requirements, prompts, userLookup, slots } = configureDemoInstanceParams()
 
 export const uiRegistry = new UIRegistry({
   appName,
   applicantDashboardIntroHeader,
   applicantDashboardIntroDetail,
-  applicantDashboardRecentDays,
+  applicantDashboardRecentDays,  
   programs,
   requirements,
   prompts,
-  userLookup
+  userLookup,
+  slots
 })
 
 function configureDemoInstanceParams () {
@@ -584,6 +587,9 @@ function configureDemoInstanceParams () {
     applicantDashboardIntroHeader: 'Start your Pet Journey Here!',
     applicantDashboardIntroDetail: 'Submitting an adoption application is the first step in adopting a cat or dog. Based on your responses you will receive a list of "eligible benefits."',
     applicantDashboardRecentDays: 30,
+    slots: {
+      applicantDashboardIntroSlot: DefaultIntroPanelDefaultSlot
+    },
     userLookup: async (login) => {
       const accessUser = await api.getAccessUser(login)
       if (!accessUser) return

--- a/ui/src/local/rc/IntroPanelDefaultSlot.svelte
+++ b/ui/src/local/rc/IntroPanelDefaultSlot.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import Time from "carbon-icons-svelte/lib/Time.svelte";
+</script>
+
+<span class="flex no-wrap pt-1">
+  <Time />
+  <p class='pl-2 text-sm'>Estimated time to complete a request is 10-20 minutes</p>
+</span>

--- a/ui/src/routes/dashboards/applicant/+page.svelte
+++ b/ui/src/routes/dashboards/applicant/+page.svelte
@@ -314,7 +314,7 @@
       title={uiRegistry.config.applicantDashboardIntroHeader}
       subtitle={uiRegistry.config.applicantDashboardIntroDetail}
 
-    >
+    >       
       <svelte:fragment slot="block-end">
         {#if displayablePeriods.length > 0}
           <!-- Show period info and action for selected period -->
@@ -382,7 +382,12 @@
         {:else}
           <p>No {uiRegistry.getWord('appRequest').toLowerCase()} {uiRegistry.getPlural('period').toLowerCase()} are currently available.</p>
         {/if}
-      </svelte:fragment>
+      </svelte:fragment>   
+      <svelte:fragment>
+        {#if uiRegistry.config.slots?.applicantDashboardIntroSlot}          
+          <svelte:component this={uiRegistry.config.slots?.applicantDashboardIntroSlot} {appRequests} {api} />
+        {/if}          
+      </svelte:fragment>   
     </IntroPanel>
   {/if}
   <!-- Application Cards -->


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/343

Issue:

Currently no ability to leverage the default slot that exists in RQ IntroPanel component

Solution:

Update UI registry config to support an `applicantDashboardIntroSlot` and render conditional component within applicant dashboard