### PR TITLE
Pass validateOnly flag to preProcessData function

### DIFF
--- a/api/src/period/period.service.ts
+++ b/api/src/period/period.service.ts
@@ -232,7 +232,7 @@ export class ConfigurationService extends AuthService<Configuration> {
     const registry = cfg.type === 'Prompt' ? promptRegistry : requirementRegistry
     const valid = registry.validateConfig(key, data)
     if (!valid) throw new Error('Invalid configuration data format.')
-    const processedData = cfg.configuredObject.definition.configuration?.preProcessData?.(data, this.ctx) ?? data
+    const processedData = cfg.configuredObject.definition.configuration?.preProcessData?.(data, this.ctx, validateOnly ?? false) ?? data
     const messages = await cfg.configuredObject.definition.configuration?.validate?.(processedData) ?? []
     for (const feedback of messages) response.addMessage(feedback.message)
     if (validateOnly || response.hasErrors()) return response

--- a/api/src/period/period.service.ts
+++ b/api/src/period/period.service.ts
@@ -224,7 +224,7 @@ export class ConfigurationService extends AuthService<Configuration> {
     return this.hasControl(cfg.type, 'configure', cfg.configuredObject.authorizationKeys)
   }
 
-  async update (periodId: string, key: string, data: any, validateOnly?: boolean) {
+  async update (periodId: string, key: string, data: any, validateOnly = false) {
     const cfg = await this.findByPeriodIdAndKey(periodId, key)
     if (!cfg) throw new Error('Configuration not found')
     if (!await this.mayUpdate(cfg)) throw new Error('You are not allowed to update this configuration.')
@@ -232,7 +232,7 @@ export class ConfigurationService extends AuthService<Configuration> {
     const registry = cfg.type === 'Prompt' ? promptRegistry : requirementRegistry
     const valid = registry.validateConfig(key, data)
     if (!valid) throw new Error('Invalid configuration data format.')
-    const processedData = cfg.configuredObject.definition.configuration?.preProcessData?.(data, this.ctx, validateOnly ?? false) ?? data
+    const processedData = cfg.configuredObject.definition.configuration?.preProcessData?.(data, this.ctx, validateOnly) ?? data
     const messages = await cfg.configuredObject.definition.configuration?.validate?.(processedData) ?? []
     for (const feedback of messages) response.addMessage(feedback.message)
     if (validateOnly || response.hasErrors()) return response

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -308,7 +308,7 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
       if (!appRequest) throw new Error('AppRequest not found')
       for (const message of prompt.definition.preValidate?.(data, allConfigData[prompt.key] ?? {}, appRequestData, allConfigData, db) ?? []) response.addMessage(message.message, message.arg, message.type)
       if (response.hasErrors()) return
-      const processedData = prompt.definition.preProcessData ? await prompt.definition.preProcessData(data, this.ctx, appRequest, appRequestData, allConfigData, db) : data
+      const processedData = prompt.definition.preProcessData ? await prompt.definition.preProcessData(data, this.ctx, appRequest, appRequestData, allConfigData, db, validateOnly) : data
       for (const message of prompt.definition.validate?.(processedData, allConfigData[prompt.key] ?? {}, appRequestData, allConfigData, db) ?? []) response.addMessage(message.message, message.arg, message.type)
       if (dataVersion != null && appRequest.dataVersion !== dataVersion) {
         throw new Error('Someone else is working on the same request and made changes since you loaded. Copy any unsaved work into another document and reload the page to see what has changed.')

--- a/api/src/registry/prompt.ts
+++ b/api/src/registry/prompt.ts
@@ -129,7 +129,7 @@ export interface ConfigurationDefinition<ConfigurationInputType = any, Configura
    * validate), but be aware of the potential transformations when you set the `arg` for each
    * MutationMessage returned by `validate`.
    */
-  preProcessData?: (data: Partial<ConfigurationInputType>, ctx: RQContext) => Promise<ConfigurationDataType> | ConfigurationDataType
+  preProcessData?: (data: Partial<ConfigurationInputType>, ctx: RQContext, validateOnly: boolean) => Promise<ConfigurationDataType> | ConfigurationDataType
   /**
    * Return validation messages to the user to help them provide correct input while
    * configuring the Prompt. Prompt configuration is for administrators to be able to
@@ -390,7 +390,7 @@ export interface PromptDefinition<DataType = any, InputDataType = DataType, Pres
    * evaluation routine, so it has to operate on post-processed data. Be aware of the potential
    * transformations when you set the `arg` for each MutationMessage returned by `validate`.
    */
-  preProcessData?: (data: InputDataType, ctx: RQContext, appRequest: AppRequest, appRequestData: Record<string, any>, allPeriodConfig: Record<string, any>, db: Queryable) => Promise<DataType> | DataType
+  preProcessData?: (data: InputDataType, ctx: RQContext, appRequest: AppRequest, appRequestData: Record<string, any>, allPeriodConfig: Record<string, any>, db: Queryable, validateOnly: boolean) => Promise<DataType> | DataType
   /**
    * Optionally provide a function that can perform server side prompt staging operations, such as querying and returning data that is meant to be readonly to the applicant.
    * Process can be specified as recurring or run on first call only. If recur is true, the process function will run on every stage of the prompt.

--- a/demos/src/complex/definitions/prompts/residence.prompts.ts
+++ b/demos/src/complex/definitions/prompts/residence.prompts.ts
@@ -18,7 +18,8 @@ export const state_residence_prompt: PromptDefinition = {
     }
     return messages
   },
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {
+    if (validateOnly) return data
     if (data.residentIdDoc) {
       for await (const file of ctx.files()) {
         const { checksum, size } = await fileHandler.put(file.stream)

--- a/demos/src/default/definitions/prompts/cat.prompts.ts
+++ b/demos/src/default/definitions/prompts/cat.prompts.ts
@@ -96,7 +96,7 @@ export const other_cats_vaccines_prompt: PromptDefinition<VaccinePromptData> = {
     }
     return messages
   },
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {    
     const shasums: string[] = []
     for await (const file of ctx.files()) {
       const hash = createHash('sha256')

--- a/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
+++ b/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
@@ -75,7 +75,8 @@ export const maintain_sys_documentation_prompt: PromptDefinition<MaintainSysDocu
   title: 'Maintain System Documentation',
   description: 'Maintain System Documentation',
   schema: MaintainSysDocumentationSchema,
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {
+    if (validateOnly) return data
     if (data.documentation) {
       for await (const file of ctx.files()) {
         const { checksum, size } = await fileHandler.put(file.stream)

--- a/demos/src/rc/definitions/prompts/shared.prompts.ts
+++ b/demos/src/rc/definitions/prompts/shared.prompts.ts
@@ -8,7 +8,8 @@ export const reccomendation_letter_prompt: PromptDefinition<ReccomendationLetter
   title: 'Reccomendation Letter',
   description: 'Reccomendation Letter',
   schema: ReccomendationLettersSchema,
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {
+    if (validateOnly) return data
     if (data.reccomendationLetter) {
       for await (const file of ctx.files()) {
         const { checksum, size } = await fileHandler.put(file.stream)

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -20,7 +20,8 @@ export const data_related_puzzle_prompt: PromptDefinition<DataRelatedPuzzlePromp
   title: 'Data related puzzle',
   description: 'Data related puzzle',
   schema: DataRelatedPuzzleSchema,
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {
+    if (validateOnly) return data
     if (data.additionalDocumentation) {
       for await (const file of ctx.files()) {
         const { checksum, size } = await fileHandler.put(file.stream)

--- a/demos/src/simple/definitions/prompts/residence.prompts.ts
+++ b/demos/src/simple/definitions/prompts/residence.prompts.ts
@@ -18,7 +18,8 @@ export const state_residence_prompt: PromptDefinition = {
     }
     return messages
   },
-  preProcessData: async (data, ctx) => {
+  preProcessData: async (data, ctx, appRequest, appRequestData, config, db, validateOnly) => {
+    if (validateOnly) return data
     if (data.residentIdDoc) {
       for await (const file of ctx.files()) {
         const { checksum, size } = await fileHandler.put(file.stream)


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/375

Issue:

RQ app dev can't conveniently validate success to externally integrated systems AND validate appropriately (during preProcess operations) without providing validateOnly details to the prompt

`preProcessData` runs on every updatePrompt mutation call to RQ API, and is routinely leveraged for data upload operations, which do not include the actual files when validateOnly is set true.  This creates a situation where RQ app dev can't know whether this is a true write, or just validation of write, and because of can't confirm a file was actually sent in the situation it is required (validateOnly set false).  RQ app dev needs to know when actual files are intended to be sent so we can confirm success to intergrated system before passing/validating the prompt for success.

Solution:

Pass validateOnly flag during period and prompt update to corresponding prompt `preProcessData` function