### PR TITLE
Extend UI registry config to support custom title and subtitle text on applicant Review submission page

### DIFF
--- a/ui/src/lib/registry.ts
+++ b/ui/src/lib/registry.ts
@@ -152,6 +152,14 @@ export interface UIConfig {
    * Defaults to 30 if not specified.
    */
   applicantDashboardRecentDays?: number
+
+  /**
+   * Applicant Review submission page title and subtitle text.
+   */
+  applicantReview?: {
+    title?: string
+    subTitle?: string
+  }
   /**
    * Whether to constrain the applicant review/submission page to a medium
    * screen-width container. Defaults to true.

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -161,13 +161,14 @@ import { api } from '$internal/api'
 
 /** RC */
 
-const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, programs, requirements, prompts, userLookup } = configureDemoInstanceParams()
+const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, applicantReview, programs, requirements, prompts, userLookup } = configureDemoInstanceParams()
 
 export const uiRegistry = new UIRegistry({
   appName,
   applicantDashboardIntroHeader,
   applicantDashboardIntroDetail,
   applicantDashboardRecentDays,
+  applicantReview,
   programs,
   requirements,
   prompts,
@@ -403,6 +404,10 @@ function configureDemoInstanceParams () {
       appName: 'MWS Technical Mentorship Experience',
       applicantDashboardIntroHeader: 'Apply for a technical mentorship here!',
       applicantDashboardIntroDetail: 'After applying for a mentorship, eligibilty will be determined based on your responses',
+      applicantReview: {
+        title: 'Review your technical mentorship application',
+        subTitle: 'Confirm the technical mentorship benefits shown are the ones you are requesting and that your responses are correct, or make changes before submitting.'
+      },
       applicantDashboardRecentDays: 30,
       userLookup: async (login) => {
         const accessUser = await api.getAccessUser(login)
@@ -584,6 +589,10 @@ function configureDemoInstanceParams () {
     applicantDashboardIntroHeader: 'Start your Pet Journey Here!',
     applicantDashboardIntroDetail: 'Submitting an adoption application is the first step in adopting a cat or dog. Based on your responses you will receive a list of "eligible benefits."',
     applicantDashboardRecentDays: 30,
+    applicantReview: {
+      title: 'Review your critter application',
+      subTitle: 'Confirm the critter benefits shown are the ones you are requesting and that your responses are correct, or make changes before submitting.'
+    },
     userLookup: async (login) => {
       const accessUser = await api.getAccessUser(login)
       if (!accessUser) return

--- a/ui/src/routes/requests/[id]/apply/review/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/review/+page.svelte
@@ -58,8 +58,8 @@
     {prequalPrompts}
     {postqualPrompts}
     {uiRegistry}
-    title="Review your application"
-    subtitle="Confirm the benefits shown are the ones you are requesting and that your responses are correct, or make changes before submitting."
+    title={uiRegistry.config.applicantReview?.title ?? "Review your application"}
+    subtitle={uiRegistry.config.applicantReview?.subTitle ?? "Confirm the benefits shown are the ones you are requesting and that your responses are correct, or make changes before submitting."}
     expandable={false}
     showWarningsInline={true}
     showAppRequestStatus={false}


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/352
https://github.com/txstate-etc/reqquest-txstate/issues/350

Issue:

Applicant review submission screen has static (non configurable) text for title and subtitle messaging.  Needs to be configurable

Resolution:

Extend UI registry config to include title and subTitle customization's for applicant review page. *Update RC demo with configured values for app review screen