### PR TITLE
Pre-Schedule release: Prevent invalidation of disqualified requirement prompts from re-enabling programs / benefits

### DIFF
--- a/api/src/appRequest/appRequest.database.ts
+++ b/api/src/appRequest/appRequest.database.ts
@@ -588,12 +588,12 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
         let hasUnanswered = false
         for (const prompt of noDisplayPrompts) {
           prompt.visibility = PromptVisibility.UNREACHABLE
-          if (!prompt.answered || prompt.invalidated) hasUnanswered = true
+          if (!prompt.answered || ([ApplicationStatus.ELIGIBLE, ApplicationStatus.PENDING].includes(application.status) && prompt.invalidated)) hasUnanswered = true
           else requiredData[prompt.key] = data[prompt.key]
         }
         let resolveInfo = requirement.definition.resolve(requiredData, configLookup[requirement.definition.key] ?? {}, configLookup)
 
-        const anyOrderAllAnswered = anyOrderPrompts.every(p => p.answered && !p.invalidated)
+        const anyOrderAllAnswered = anyOrderPrompts.every(p => p.answered && !([ApplicationStatus.ELIGIBLE, ApplicationStatus.PENDING].includes(application.status) && p.invalidated))
         for (const prompt of anyOrderPrompts) {
           prompt.visibility = PromptVisibility.UNREACHABLE
           if (!hasUnanswered && resolveInfo.status === RequirementStatus.PENDING) {
@@ -614,7 +614,7 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
             else prompt.visibility = PromptVisibility.AVAILABLE
             promptsSeenInApplication.add(prompt.key)
             promptsSeenInRequest.add(prompt.key)
-            if (prompt.answered && !prompt.invalidated) {
+            if (prompt.answered && !([ApplicationStatus.ELIGIBLE, ApplicationStatus.PENDING].includes(application.status) && prompt.invalidated)) {
               requiredData[prompt.key] = data[prompt.key]
               resolveInfo = requirement.definition.resolve(requiredData, configLookup[requirement.definition.key] ?? {}, configLookup)
             } else hasUnanswered = true

--- a/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
+++ b/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
@@ -55,7 +55,10 @@ export const assess_technical_troubleshooting_prompt: PromptDefinition<AssessTec
       complexity: 1
     }
   },
-  invalidUponChange: [{ promptKey: 'technical_troubleshooting_prompt', reason: 'Troubleshooting was poorly described, make changes and resubmit' }]
+  invalidUponChange: [
+    { promptKey: 'technical_troubleshooting_prompt', reason: 'Troubleshooting was poorly described, make changes and resubmit' },
+    { promptKey: 'critical_thinking_prompt', reason: 'Need to find out why someone bad at technical troubleshooting would be good at critical thinking'}
+  ]
 }
 
 export const support_communication_prompt: PromptDefinition<SupportCommunicationData> = {

--- a/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
+++ b/demos/src/rc/definitions/prompts/applicationManagement.prompts.ts
@@ -1,4 +1,4 @@
-import { MutationMessage, PromptDefinition } from '@reqquest/api'
+import { MutationMessage, PromptDefinition, InvalidatedResponse } from '@reqquest/api'
 import { AssessMaintainSysDocumentationData, AssessMaintainSysDocumentationSchema, AssessSupportCommunicationData, AssessSupportCommunicationSchema, AssessTechincalTroubleshootingData, AssessTechincalTroubleshootingSchema, MaintainSysDocumentationData, MaintainSysDocumentationSchema, SupportCommunicationData, SupportCommunicationSchema, TechincalTroubleshootingData, TechincalTroubleshootingSchema } from '../models/index.js'
 import { MutationMessageType } from '@txstate-mws/graphql-server'
 import { fileHandler } from 'fastify-txstate'
@@ -55,10 +55,19 @@ export const assess_technical_troubleshooting_prompt: PromptDefinition<AssessTec
       complexity: 1
     }
   },
-  invalidUponChange: [
-    { promptKey: 'technical_troubleshooting_prompt', reason: 'Troubleshooting was poorly described, make changes and resubmit' },
-    { promptKey: 'critical_thinking_prompt', reason: 'Need to find out why someone bad at technical troubleshooting would be good at critical thinking'}
-  ]
+  invalidUponChange: (data: any, config: any, appRequestData: Record<string, any>, allPeriodConfig: Record<string, any>) => {
+    const invalidatedResponse: InvalidatedResponse[] = []
+    if (data && !data.demonstrateTechincalTroubleshooting) {
+      invalidatedResponse.push({ promptKey: 'technical_troubleshooting_prompt', reason: 'Troubleshooting was poorly described, make changes and resubmit' },
+                              { promptKey: 'critical_thinking_prompt', reason: 'Need to find out why someone bad at technical troubleshooting would be good at critical thinking'})
+    }
+    return invalidatedResponse
+  },
+  validUponChange: (data: any, config: any, appRequestData: Record<string, any>, allPeriodConfig: Record<string, any>) => {
+    return (data && data.demonstrateTechincalTroubleshooting)
+      ? ['technical_troubleshooting_prompt', 'critical_thinking_prompt']
+      : []
+  }
 }
 
 export const support_communication_prompt: PromptDefinition<SupportCommunicationData> = {

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -83,6 +83,7 @@ export const critical_thinking_req: RequirementDefinition = {
   resolve: (data, config) => {
     const writtenAutomationData = data['critical_thinking_prompt'] as CriticalThinkingPromptData
     if (writtenAutomationData?.criticalThinkingAnswer == null) return { status: RequirementStatus.PENDING }
+    if (writtenAutomationData?.criticalThinkingAnswer == 'NA') return { status: RequirementStatus.DISQUALIFYING, reason: 'NA for critical thinking answer is disqualifying' }
     return { status: RequirementStatus.MET }
   }
 }

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -832,14 +832,7 @@ class API extends APIBase {
           navTitle: true,
           programKey: true,
           status: true,
-          ineligiblePhase: true,
-          requirements : {
-            type: true,
-            prompts: {
-              key: true,
-              invalidated: true
-            }
-          }
+          ineligiblePhase: true
         },
         actions: {
           acceptOffer: true,

--- a/ui/src/internal/api.ts
+++ b/ui/src/internal/api.ts
@@ -832,7 +832,14 @@ class API extends APIBase {
           navTitle: true,
           programKey: true,
           status: true,
-          ineligiblePhase: true
+          ineligiblePhase: true,
+          requirements : {
+            type: true,
+            prompts: {
+              key: true,
+              invalidated: true
+            }
+          }
         },
         actions: {
           acceptOffer: true,

--- a/ui/src/internal/components/ApplicantProgramList.svelte
+++ b/ui/src/internal/components/ApplicantProgramList.svelte
@@ -91,7 +91,7 @@
 <section class="programs-container">
   <header>
     <div class="program column">Program</div>
-    <div class="status column">Eligibility</div>
+    <div class="status column">Status</div>
   </header>
   {#each applications as application (application.id)}
     {@const programStatus = programButtonStatus[application.id]}

--- a/ui/src/internal/components/ApplicantProgramListTooltip.svelte
+++ b/ui/src/internal/components/ApplicantProgramListTooltip.svelte
@@ -17,8 +17,7 @@
       {#each application.warningReasons as reason (reason)}
         <p>{reason}</p>
       {/each}    
-    {:else if application.metReasons.length}
-       <p><strong>Eligible Because:</strong></p>
+    {:else if application.metReasons.length}       
       {#each application.metReasons as reason (reason)}
         <p>{reason}</p>
       {/each}

--- a/ui/src/internal/components/ApplicationDetailsView.svelte
+++ b/ui/src/internal/components/ApplicationDetailsView.svelte
@@ -112,7 +112,7 @@
         {/if}
         <!-- Ineligible Status List -->
          {#if ineligibleApplications.length > 0}
-            <Panel title="Ineligible programs" expandable={true} expanded={(eligibleApplications.length === 0)}>
+            <Panel title="Ineligible benefits" expandable={true} expanded={(eligibleApplications.length === 0)}>
               <ApplicantProgramList applications={ineligibleApplications} {appRequest} viewMode={statusDisplay === 'tags'} {showTooltipsAsText} />
             </Panel>
          {/if}         

--- a/ui/src/lib/typed-client/schema.graphql
+++ b/ui/src/lib/typed-client/schema.graphql
@@ -211,6 +211,7 @@ input AccessTagInput {
 
 """A user that has or once had access to the system."""
 type AccessUser {
+  email: String
   fullname: String!
   groups: [String!]!
   login: ID!

--- a/ui/src/lib/typed-client/schema.ts
+++ b/ui/src/lib/typed-client/schema.ts
@@ -153,6 +153,7 @@ export interface AccessTagCategory {
 
 /** A user that has or once had access to the system. */
 export interface AccessUser {
+    email: (Scalars['String'] | null)
     fullname: Scalars['String']
     groups: Scalars['String'][]
     login: Scalars['ID']
@@ -1021,6 +1022,7 @@ tag: Scalars['String']}
 
 /** A user that has or once had access to the system. */
 export interface AccessUserGenqlSelection{
+    email?: boolean | number
     fullname?: boolean | number
     groups?: boolean | number
     login?: boolean | number

--- a/ui/src/lib/typed-client/types.ts
+++ b/ui/src/lib/typed-client/types.ts
@@ -321,6 +321,9 @@ export default {
             ]
         },
         "AccessUser": {
+            "email": [
+                85
+            ],
             "fullname": [
                 85
             ],

--- a/ui/src/local/rc/AssessTechnicalTroubleshooting.svelte
+++ b/ui/src/local/rc/AssessTechnicalTroubleshooting.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import { FieldRadio } from '@txstate-mws/carbon-svelte'
-  import type { AssessTechnicalTroubleshooting } from './types.js'
-  export let gatheredConfigData
-  export let data: Partial<AssessTechnicalTroubleshooting>
 </script>
 
 <FieldRadio boolean path="demonstrateTechincalTroubleshooting" legendText="Did the applicant demonstrate a structured methodology for troubleshooting?" items={[{ label: 'Yes', value: true }, { label: 'No', value: false }]} />

--- a/ui/src/local/rc/AssessTechnicalTroubleshootingDisplay.svelte
+++ b/ui/src/local/rc/AssessTechnicalTroubleshootingDisplay.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-    import { booleanToWord } from "$internal"
-  import type { AssessTechnicalTroubleshooting } from "./types"
-
-  export let data: AssessTechnicalTroubleshooting
+  import { booleanToWord } from "$internal"
+  export let preloadData
+  export let data
 </script>
 <p class="text-xs">Did the applicant demonstrate a structured methodology for troubleshooting?</p>
-<p>{booleanToWord(data?.demonstrateTechincalTroubleshooting)}</p>
+<p>{booleanToWord(data?.demonstrateTechincalTroubleshooting ?? preloadData?.demonstrateTechincalTroubleshooting)}</p>
 <p class="text-xs">Complexity rating (1-5)</p>
-<p>{data?.complexity}</p>
+<p>{data?.complexity ?? preloadData?.complexity}</p>
 

--- a/ui/src/routes/requests/[id]/apply/programs/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/programs/+page.svelte
@@ -27,7 +27,7 @@
   })
 </script>
 
-<ProgressNavContainer title="Your potential programs" subtitle='Select "Start" to answer additional qualifying questions about the benefits you may be eligible for.'>
+<ProgressNavContainer title="Your potential benefits" subtitle='Select "Start" to answer additional qualifying questions about the benefits you may be eligible for.'>
   {@const eligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase == null)}
   <div class="max-w-screen-md mx-auto">    
     {#if eligibleApplicationsForNav.length > 0} 
@@ -42,7 +42,7 @@
   {@const ineligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase === enumIneligiblePhases.PREQUAL || a.ineligiblePhase === enumIneligiblePhases.QUALIFICATION)}
   {#if ineligibleApplicationsForNav.length > 0}  
     <div class="max-w-screen-md mx-auto">    
-      <Panel title="Ineligible programs" expandable={true} expanded={true}>
+      <Panel title="Ineligible benefits" expandable={true} expanded={true}>
         <ApplicantProgramList applications={ineligibleApplicationsForNav} appRequest={appRequestForExport} />
       </Panel>
     </div>

--- a/ui/src/routes/requests/[id]/apply/programs/+page.svelte
+++ b/ui/src/routes/requests/[id]/apply/programs/+page.svelte
@@ -27,7 +27,7 @@
   })
 </script>
 
-<ProgressNavContainer title="Your potential benefits" subtitle='Select "Start" to answer additional qualifying questions about the benefits you may be eligible for.'>
+<ProgressNavContainer title="Your potential benefits" subtitle='Based on your responses for far, you may be eligible for the benefits listed below.  If you believe you qualify for additional benefits, you may need to reviews your answers, complete additional questions, or provides supporting documentation before eligibility can be confirmed.'>
   {@const eligibleApplicationsForNav = applicationsForNav.filter(a => a.ineligiblePhase == null)}
   <div class="max-w-screen-md mx-auto">    
     {#if eligibleApplicationsForNav.length > 0} 


### PR DESCRIPTION
Issue:

If a reviewer invalidates a prompt that is part of a DISQUAL'd requirement, that requirement is then placed back into a pending state.  This results in an addition of all PENDING programs immediately into the reviewer view, which is unwanted.

Also immediate fix need to resolve problem in RQ-next

Solution:

Only consider invalidated prompts as important (part of the evaluation assessment to determine status) if they are within pending or eligible apps.
