### PR TITLE
Implement non blocking workflows that can emerge and remain active for the remainder of appRequest lifecycle

### DIFF
--- a/api/src/appRequest/appRequest.database.ts
+++ b/api/src/appRequest/appRequest.database.ts
@@ -336,9 +336,11 @@ export async function acceptOffer (appRequestId: number, nextPhase: AppRequestPh
     if (existingDataVersion == null) throw new Error(`AppRequest ${appRequestId} not found`)
     if (incomingDataVersion && existingDataVersion !== incomingDataVersion) throw new Error('Someone else is working on the same request and made changes since you loaded. Reload the page to try again.')
     const applications = await getApplications({ appRequestIds: [String(appRequestId)] }, db)
-    const workflowStages = await getPeriodWorkflowStages({ periodIds: [applications[0]?.periodId], hasEnabledRequirements: true, blocking: false }, db)
     for (const application of applications) {
-      await db.execute('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [ApplicationPhase.WORKFLOW_NONBLOCKING, workflowStages.find(w => w.programKey === application.programKey)?.key, application.internalId])
+      // non-blocking workflow is non-sequential so there is no active stage pointer. All non-blocking requirements
+      // become visible/editable at once and marks the application READY_TO_COMPLETE once they are all
+      // resolved. Completion is via the whole-request complete action, not per stage advancing.
+      await db.execute('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [ApplicationPhase.WORKFLOW_NONBLOCKING, null, application.internalId])
     }
     await db.update('UPDATE app_requests SET phase = ? WHERE id = ?', [nextPhase, appRequestId])
     await evaluateAppRequest(appRequestId, db)
@@ -374,10 +376,9 @@ export async function appRequestReturnToNonBlocking (appRequestId: number) {
   return await appRequestTransaction(appRequestId, async db => {
     await db.execute('UPDATE app_requests SET phase = ? WHERE id = ?', [AppRequestPhase.WORKFLOW_NONBLOCKING, appRequestId])
     const applications = await getApplications({ appRequestIds: [String(appRequestId)] }, db)
-    const workflowStages = await getPeriodWorkflowStages({ periodIds: [applications[0]?.periodId], hasEnabledRequirements: true, blocking: false }, db)
     for (const app of applications) {
-      const workflowStage = workflowStages.toReversed().find(s => s.programKey === app.programKey)
-      await db.execute('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [workflowStage == null ? ApplicationPhase.READY_TO_COMPLETE : ApplicationPhase.WORKFLOW_NONBLOCKING, workflowStage?.key, app.internalId])
+      // non-blocking workflow is non-sequential so recompute readiness from the resolution of all non-blocking requirements.
+      await db.execute('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [ApplicationPhase.WORKFLOW_NONBLOCKING, null, app.internalId])
     }
     await evaluateAppRequest(appRequestId, db)
   })
@@ -575,20 +576,23 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
       })
 
       // if we are in applicant phase, we only need to evaluate prequal, postqual, and qualification requirements
-      // acceptance requirements if we are in acceptance phase, etc
+      // acceptance requirements if we are in acceptance phase, etc.
+      // non-blocking workflow is  not sequential, so take into account here
       const sortedRequirements = phase === 'complete'
         ? []
         : phase === 'applicant'
           ? presubmitRequirements
           : phase === 'acceptance'
             ? acceptRequirements
-            : phase === 'blocking' || phase === 'nonblocking'
-              ? currentWorkflowRequirements
-              : reviewRequirements
+            : phase === 'nonblocking'
+              ? nonblockingWorkflowRequirements
+              : phase === 'blocking'
+                ? currentWorkflowRequirements
+                : reviewRequirements
 
       // requirements from non-blocking workflow stages whose reached emergence phase are
-      // surfaced alongside the phase's normal requirements.
-      // Must inject the emerged bucket for the earlier review/blocking/acceptance phases. Non-blocking works normal still.
+      // surfaced alongside the phase's normal requirements in the earlier phases.
+      // in non-blocking phase they are already all in sortedRequirements
       // They are appended after sortedRequirements and excluded from eligibility decisions.
       const emergedExtraRequirements = phase === 'acceptance' || phase === 'blocking' || phase === 'review'
         ? emergedNonblockingWorkflowRequirements.filter(req => !sortedRequirements.includes(req))
@@ -694,11 +698,15 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
       application.phase = phase === 'complete'
         ? ApplicationPhase.COMPLETE
         : phase === 'nonblocking'
-          ? application.workflowStageKey
-            ? requirementsResolution === 'pass' && !application.awaitingCorrection
-              ? ApplicationPhase.READY_FOR_WORKFLOW
+          // Ineligible applications are disqualified and have no post-acceptance work
+          ? application.ineligiblePhase != null
+            ? ApplicationPhase.READY_TO_COMPLETE
+          // non-blocking workflow is non sequential, a non-blocking fail never blocks completion, so only a pending holds it back.
+            : requirementsResolution !== 'pending' && !application.awaitingCorrection
+              ? nonblockingWorkflowRequirements.length
+                ? ApplicationPhase.READY_FOR_WORKFLOW
+                : ApplicationPhase.READY_TO_COMPLETE
               : ApplicationPhase.WORKFLOW_NONBLOCKING
-            : ApplicationPhase.READY_TO_COMPLETE
           : phase === 'acceptance'
             ? requirementsResolution !== 'pending' && !application.awaitingCorrection
               ? ApplicationPhase.READY_TO_ACCEPT
@@ -748,7 +756,8 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
       } else if (phase === 'blocking') {
         requirementsToLock.push(...reviewRequirements, ...blockingWorkflowRequirements.slice(0, findIndex(blockingWorkflowRequirements, r => r.workflowStageKey === application.workflowStageKey) ?? blockingWorkflowRequirements.length))
       } else if (phase === 'nonblocking') {
-        requirementsToLock.push(...reviewRequirements, ...blockingWorkflowRequirements, ...acceptanceRequirements, ...nonblockingWorkflowRequirements.slice(0, findIndex(nonblockingWorkflowRequirements, r => r.workflowStageKey === application.workflowStageKey) ?? nonblockingWorkflowRequirements.length))
+        // never lock non-blocking workflow requirements, once emerged they stay editable for the remainder of the lifecycle.
+        requirementsToLock.push(...reviewRequirements, ...blockingWorkflowRequirements, ...acceptanceRequirements)
       } else if (phase === 'acceptance') {
         requirementsToLock.push(...reviewRequirements, ...blockingWorkflowRequirements)
       }
@@ -779,17 +788,18 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
       else appRequest.status = AppRequestStatus.DISQUALIFIED
     } else if (applications.some(a => a.phase === ApplicationPhase.READY_TO_SUBMIT) && !applications.some(a => a.status === ApplicationStatus.PENDING) && !appRequest.awaitingCorrection) appRequest.status = AppRequestStatus.READY_TO_SUBMIT
     // special case for single-program systems with no blocking workflow stages - we set the appRequest to REVIEW_COMPLETE so
-    // the reviewers can do the appRequest-level "Complete Review" right away instead of having to advance the application first
-    else if (applications.length === 1 && !workflowStages.filter(s => s.blocking).length && (applications[0].phase === ApplicationPhase.READY_FOR_WORKFLOW || applications[0].phase === ApplicationPhase.REVIEW_COMPLETE) && !appRequest.awaitingCorrection) appRequest.status = AppRequestStatus.REVIEW_COMPLETE
+    // the reviewers can do the appRequest-level "Complete Review" right away instead of having to advance the application first.
+    // READY_FOR_WORKFLOW is a review-phase (SUBMITTED) signal here, but in the non-blocking phase it means 'ready to send to complete' and is handled below, so restrict this to SUBMITTED.
+    else if (appRequest.phase === AppRequestPhase.SUBMITTED && applications.length === 1 && !workflowStages.filter(s => s.blocking).length && (applications[0].phase === ApplicationPhase.READY_FOR_WORKFLOW || applications[0].phase === ApplicationPhase.REVIEW_COMPLETE) && !appRequest.awaitingCorrection) appRequest.status = AppRequestStatus.REVIEW_COMPLETE
     // exclude prequal and qual ineligible applications from affecting AppRequestStatus, since they never require approval to the next step and we don't want them blocking the appRequest from moving forward
-    else if (applications.filter(a => a.status !== ApplicationStatus.INELIGIBLE || (a.ineligiblePhase && [IneligiblePhases.APPROVAL].includes(a.ineligiblePhase))).some(a => a.phase === ApplicationPhase.READY_FOR_WORKFLOW)) appRequest.status = AppRequestStatus.APPROVAL
+    else if (appRequest.phase === AppRequestPhase.SUBMITTED && applications.filter(a => a.status !== ApplicationStatus.INELIGIBLE || (a.ineligiblePhase && [IneligiblePhases.APPROVAL].includes(a.ineligiblePhase))).some(a => a.phase === ApplicationPhase.READY_FOR_WORKFLOW)) appRequest.status = AppRequestStatus.APPROVAL
     else if (applications.some(a => a.phase === ApplicationPhase.REVIEW_COMPLETE) && !applications.some(a => a.status === ApplicationStatus.PENDING) && !appRequest.awaitingCorrection) appRequest.status = AppRequestStatus.REVIEW_COMPLETE
     else if (applications.some(a => a.phase === ApplicationPhase.READY_TO_ACCEPT) && !applications.some(a => a.status === ApplicationStatus.PENDING) && !appRequest.awaitingCorrection) appRequest.status = AppRequestStatus.READY_TO_ACCEPT
     else if (applications.some(a => a.phase === ApplicationPhase.ACCEPTANCE)) appRequest.status = AppRequestStatus.ACCEPTANCE
     else if (applications.some(a => a.phase === ApplicationPhase.PREAPPROVAL)) appRequest.status = AppRequestStatus.PREAPPROVAL
     else if (applications.some(a => a.phase === ApplicationPhase.WORKFLOW_BLOCKING)) appRequest.status = AppRequestStatus.APPROVAL
     else if (applications.some(a => a.phase === ApplicationPhase.APPROVAL)) appRequest.status = AppRequestStatus.APPROVAL
-    else if (applications.some(a => a.phase === ApplicationPhase.WORKFLOW_NONBLOCKING)) appRequest.status = applications.some(a => a.status === ApplicationStatus.ACCEPTED) ? AppRequestStatus.ACCEPTED : AppRequestStatus.APPROVED
+    else if (applications.some(a => a.phase === ApplicationPhase.WORKFLOW_NONBLOCKING || a.phase === ApplicationPhase.READY_FOR_WORKFLOW)) appRequest.status = applications.some(a => a.status === ApplicationStatus.ACCEPTED) ? AppRequestStatus.ACCEPTED : AppRequestStatus.APPROVED
     else if (applications.every(a => a.phase === ApplicationPhase.COMPLETE || a.phase === ApplicationPhase.READY_TO_COMPLETE)) appRequest.status = applications.some(a => a.status === ApplicationStatus.ACCEPTED) ? AppRequestStatus.ACCEPTED : AppRequestStatus.APPROVED
     else appRequest.status = AppRequestStatus.STARTED
 

--- a/api/src/appRequest/appRequest.database.ts
+++ b/api/src/appRequest/appRequest.database.ts
@@ -6,7 +6,7 @@ import db from 'mysql2-async/db'
 import { clone, findIndex, groupby, isNotBlank, keyby, omit, stringify } from 'txstate-utils'
 import {
   ApplicationPhase, ApplicationRequirement, ApplicationStatus, AppRequest, AppRequestActivity, AppRequestActivityFilters,
-  AppRequestFilter, AppRequestPhase, AppRequestStatus, getApplications, getPeriodWorkflowStages, IneligiblePhases, Pagination,
+  AppRequestFilter, AppRequestPhase, appRequestPhaseReached, AppRequestStatus, getApplications, getPeriodWorkflowStages, IneligiblePhases, Pagination,
   PaginationInfoWithTotalItems, programRegistry, promptRegistry, PromptVisibility, RequirementPrompt, RequirementStatus,
   RequirementType, RQContext, syncApplications, syncPromptRecords, syncRequirementRecords, updateApplicationsComputed,
   updatePromptComputed, updateRequirementComputed, type AppRequestData
@@ -565,6 +565,14 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
       const presubmitRequirements = [...prequalRequirements, ...qualificationRequirements, ...postqualRequirements]
       const reviewRequirements = [...presubmitRequirements, ...preapprovalRequirements, ...approvalRequirements]
       const acceptRequirements = [...reviewRequirements, ...blockingWorkflowRequirements, ...acceptanceRequirements]
+      // Non-blocking workflow stages may now define an emergence phase at which their requirements first become
+      // visible/editable, rather than always waiting for the request to reach the WORKFLOW_NONBLOCKING phase.
+      // Must NEVER influence eligibility/status resolution since these are non-blocking
+      // so kept out of sortedRequirements
+      const emergedNonblockingWorkflowRequirements = nonblockingWorkflowRequirements.filter(req => {
+        const emergence = programRegistry.getWorkflowStageByKey(req.workflowStageKey)?.nonBlockingEmergence ?? AppRequestPhase.WORKFLOW_NONBLOCKING
+        return appRequestPhaseReached(appRequest.phase, emergence)
+      })
 
       // if we are in applicant phase, we only need to evaluate prequal, postqual, and qualification requirements
       // acceptance requirements if we are in acceptance phase, etc
@@ -578,10 +586,21 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
               ? currentWorkflowRequirements
               : reviewRequirements
 
+      // requirements from non-blocking workflow stages whose reached emergence phase are
+      // surfaced alongside the phase's normal requirements.
+      // Must inject the emerged bucket for the earlier review/blocking/acceptance phases. Non-blocking works normal still.
+      // They are appended after sortedRequirements and excluded from eligibility decisions.
+      const emergedExtraRequirements = phase === 'acceptance' || phase === 'blocking' || phase === 'review'
+        ? emergedNonblockingWorkflowRequirements.filter(req => !sortedRequirements.includes(req))
+        : []
+      const displayedRequirements = [...sortedRequirements, ...emergedExtraRequirements]
+
       const promptsSeenInApplication = new Set<string>()
       let applicationIsIneligible = false
       let firstAwaitingCorrectionRequirement: typeof sortedRequirements[number] | undefined
-      for (const requirement of sortedRequirements) {
+      for (const requirement of displayedRequirements) {
+        // identify if requirement influences eligibility (accommodate emerged non blocking that may be mixed in)
+        const isResolutionRequirement = sortedRequirements.includes(requirement)
         const requiredData = {} as AppRequestData
         const prompts = promptLookup[requirement.id] ?? []
         // matches the `moot` flag stored on regular prompts below: a prior requirement already
@@ -628,12 +647,14 @@ export async function evaluateAppRequest (appRequestInternalId: number, tdb?: Qu
 
         requirement.status = resolveInfo.status
         requirement.statusReason = resolveInfo.reason
-        if (requirement.status === RequirementStatus.DISQUALIFYING) applicationIsIneligible = true
+        if (requirement.status === RequirementStatus.DISQUALIFYING && isResolutionRequirement) applicationIsIneligible = true
 
         // an invalidated prompt that the user can currently reach must be re-answered before the
         // application may move forward; remember the first requirement that needs the attention so
-        // the phase can point at it
-        if (firstAwaitingCorrectionRequirement == null && !promptsAreMoot && prompts.some(p => p.invalidated && p.visibility === PromptVisibility.AVAILABLE)) {
+        // the phase can point at it.
+        // non-blocking requirements (that can now emerge early) are excluded (not resolution requirement) so they can never
+        // hold back the application's phase progression.
+        if (isResolutionRequirement && firstAwaitingCorrectionRequirement == null && !promptsAreMoot && prompts.some(p => p.invalidated && p.visibility === PromptVisibility.AVAILABLE)) {
           firstAwaitingCorrectionRequirement = requirement
         }
       }

--- a/api/src/appRequest/appRequest.model.ts
+++ b/api/src/appRequest/appRequest.model.ts
@@ -71,6 +71,28 @@ registerEnumType(AppRequestPhase, {
   }
 })
 
+/**
+ * Although the AppRequestPhase enum currently lists phases in chronological order,
+ * this is intended to guarantee expected order.  Safety since AppRequestPhase
+ * doesn't explicitly project order.
+ */
+export const appRequestPhaseOrder: AppRequestPhase[] = [
+  AppRequestPhase.STARTED,
+  AppRequestPhase.SUBMITTED,
+  AppRequestPhase.ACCEPTANCE,
+  AppRequestPhase.WORKFLOW_NONBLOCKING,
+  AppRequestPhase.COMPLETE
+]
+
+/**
+ * Returns true if current is at or beyond target in the natural phase progression. created
+ * specifically for non blocking workflows to confirm phase has been reached
+ * so its requirements should become visible/editable for the remainder of the life cycle.
+ */
+export function appRequestPhaseReached (current: AppRequestPhase, target: AppRequestPhase) {
+  return appRequestPhaseOrder.indexOf(current) >= appRequestPhaseOrder.indexOf(target)
+}
+
 @ObjectType({ description: 'Represents a group of applications all being applied for at the same time. As part of the request, multiple applications will be created and either eliminated as ineligible or submitted for approval.' })
 export class AppRequest {
   constructor (row: AppRequestRow, tags?: Record<string, string[]>) {

--- a/api/src/appRequest/appRequest.model.ts
+++ b/api/src/appRequest/appRequest.model.ts
@@ -86,7 +86,7 @@ export const appRequestPhaseOrder: AppRequestPhase[] = [
 
 /**
  * Returns true if current is at or beyond target in the natural phase progression. created
- * specifically for non blocking workflows to confirm phase has been reached
+ * specifically for non blocking workflows to confirm emergence phase has been reached
  * so its requirements should become visible/editable for the remainder of the life cycle.
  */
 export function appRequestPhaseReached (current: AppRequestPhase, target: AppRequestPhase) {

--- a/api/src/appRequest/appRequest.service.ts
+++ b/api/src/appRequest/appRequest.service.ts
@@ -359,8 +359,11 @@ export class AppRequestService extends AuthService<AppRequest> {
 
   mayReturnToNonBlocking (appRequest: AppRequest) {
     if (this.isClosed(appRequest)) return false
-    if (appRequest.phase !== AppRequestPhase.COMPLETE) return false
     if (!this.isNonBlockingWorkflowPeriod(appRequest.periodId)) return false
+    // available once the non-blocking workflow is finished, so a reviewer can reopen it to fix an
+    // audit (non blocking working phase) answer.
+    const nonBlockingFinished = appRequest.phase === AppRequestPhase.COMPLETE || (appRequest.phase === AppRequestPhase.WORKFLOW_NONBLOCKING && appRequest.readyToComplete)
+    if (!nonBlockingFinished) return false
     if (this.isOwn(appRequest) && !this.hasControl('AppRequest', 'review_own', appRequest.tags)) return false
     return this.hasControl('AppRequest', 'review', appRequest.tags)
   }

--- a/api/src/application/application.database.ts
+++ b/api/src/application/application.database.ts
@@ -127,21 +127,12 @@ export async function reverseWorkflow (applicationId: string, tdb: Queryable = d
     WHERE w.programKey=? AND w.periodId=?
     ORDER BY w.evaluationOrder
   `, [application.programKey, application.periodId])
+  // Non-blocking workflow stages are excluded from the reverse (return) order — reversal only steps back
+  // through the blocking workflow and never targets a non-blocking stage. Aligns with new non-blocking
+  // workflows being allowed to surface earlier
   const blocking = stages.filter(stage => !!stage.blocking)
-  const nonblocking = stages.filter(stage => !stage.blocking)
-  const currentlyBlocking = application.appRequestPhase === AppRequestPhase.WORKFLOW_NONBLOCKING ? false : true
-  const activeStages = currentlyBlocking ? blocking : nonblocking
-  const fromStage = activeStages.find(stage => stage.stageKey === application.workflowStageKey)
-  const currIdx = application.phase === ApplicationPhase.COMPLETE ? activeStages.length : activeStages.findIndex(stage => stage.stageKey === fromStage?.stageKey)
-  let toStage: PeriodWorkflowRow | undefined = activeStages[currIdx - 1]
-  let toPhase: ApplicationPhase | undefined
-
-  if (currentlyBlocking) {
-    toPhase = toStage ? ApplicationPhase.WORKFLOW_BLOCKING : ApplicationPhase.APPROVAL
-  } else if (toStage != null) {
-    toPhase = ApplicationPhase.WORKFLOW_NONBLOCKING
-  } else {
-    throw new Error('Cannot reverse workflow any further.')
-  }
+  const currIdx = blocking.findIndex(stage => stage.stageKey === application.workflowStageKey)
+  const toStage: PeriodWorkflowRow | undefined = currIdx > 0 ? blocking[currIdx - 1] : undefined
+  const toPhase = toStage ? ApplicationPhase.WORKFLOW_BLOCKING : ApplicationPhase.APPROVAL
   await tdb.update('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [toPhase, toStage?.stageKey, applicationId])
 }

--- a/api/src/application/application.database.ts
+++ b/api/src/application/application.database.ts
@@ -129,9 +129,12 @@ export async function reverseWorkflow (applicationId: string, tdb: Queryable = d
   `, [application.programKey, application.periodId])
   // Non-blocking workflow stages are excluded from the reverse (return) order — reversal only steps back
   // through the blocking workflow and never targets a non-blocking stage. Aligns with new non-blocking
-  // workflows being allowed to surface earlier
+  // workflows being allowed to surface earlier.
   const blocking = stages.filter(stage => !!stage.blocking)
-  const currIdx = blocking.findIndex(stage => stage.stageKey === application.workflowStageKey)
+  // Needed to take into consideration blocking workflow stages and not just move back to APPROVAL
+  const currIdx = application.phase === ApplicationPhase.REVIEW_COMPLETE
+    ? blocking.length
+    : blocking.findIndex(stage => stage.stageKey === application.workflowStageKey)
   const toStage: PeriodWorkflowRow | undefined = currIdx > 0 ? blocking[currIdx - 1] : undefined
   const toPhase = toStage ? ApplicationPhase.WORKFLOW_BLOCKING : ApplicationPhase.APPROVAL
   await tdb.update('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [toPhase, toStage?.stageKey, applicationId])

--- a/api/src/application/application.database.ts
+++ b/api/src/application/application.database.ts
@@ -80,6 +80,13 @@ export async function advanceWorkflow (applicationId: string, tdb: Queryable = d
   if (!application) throw new Error(`Application not found: ${applicationId}`)
   if (application.phase !== ApplicationPhase.READY_FOR_WORKFLOW) throw new Error('Application is not ready to advance workflow.')
 
+  // In the non-blocking (post-acceptance) phase the workflow is non-sequential, no stage stepping,
+  // this is the single explicit 'Send to Complete' action.
+  if (application.appRequestPhase === AppRequestPhase.WORKFLOW_NONBLOCKING) {
+    await tdb.update('UPDATE applications SET computedPhase = ?, workflowStage = ? WHERE id = ?', [ApplicationPhase.COMPLETE, null, applicationId])
+    return
+  }
+
   const stages = await tdb.getall<PeriodWorkflowRow>(`
     SELECT DISTINCT w.* FROM period_workflow_stages w
     INNER JOIN application_requirements r ON r.workflowStage = w.stageKey
@@ -130,9 +137,8 @@ export async function reverseWorkflow (applicationId: string, tdb: Queryable = d
     ORDER BY w.evaluationOrder
   `, [application.programKey, application.periodId])
   // Non-blocking workflow stages are excluded from the reverse (return) order — reversal only steps back
-  // through the blocking workflow and never targets a non-blocking stage. Aligns with new non-blocking
-  // workflows being allowed to surface earlier.
-  const blocking = stages.filter(stage => !!stage.blocking)
+  // through the blocking workflow. The stage definition (registry) is authoritative for nonBlocking
+  const blocking = stages.filter(stage => !!stage.blocking && !programRegistry.getWorkflowStageByKey(stage.stageKey)?.nonBlocking)
   // Needed to take into consideration blocking workflow stages and not just move back to APPROVAL
   const currIdx = application.phase === ApplicationPhase.REVIEW_COMPLETE
     ? blocking.length

--- a/api/src/application/application.database.ts
+++ b/api/src/application/application.database.ts
@@ -119,6 +119,8 @@ export async function advanceWorkflow (applicationId: string, tdb: Queryable = d
 export async function reverseWorkflow (applicationId: string, tdb: Queryable = db) {
   const [application] = await getApplications({ ids: [applicationId] }, tdb)
   if (!application) throw new Error(`Application not found: ${applicationId}`)
+  // reversing between non-blocking stages must never occur in any AppRequestPhase since they are no longer sequential, exclude from the reverse order.
+  if (programRegistry.getWorkflowStageByKey(application.workflowStageKey)?.nonBlocking) throw new Error('Non-blocking workflow stages cannot be reversed.')
 
   const stages = await tdb.getall<PeriodWorkflowRow>(`
     SELECT DISTINCT w.* FROM period_workflow_stages w

--- a/api/src/application/application.resolver.ts
+++ b/api/src/application/application.resolver.ts
@@ -44,7 +44,7 @@ export class ApplicationResolver {
     return await ctx.svc(ApplicationService).advanceWorkflow(applicationId)
   }
 
-  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application back to the previous workflow stage. If on the first blocking workflow stage, moves back to APPROVAL. If on the first non-blocking workflow, throws an error.' })
+  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application back to the previous blocking workflow stage. Non-blocking workflow stages are excluded from the reverse order, so this only steps back through the blocking workflow during the review (SUBMITTED) phase. If on the first blocking workflow stage, moves back to APPROVAL.' })
   async reverseWorkflow (@Ctx() ctx: RQContext, @Arg('applicationId', type => ID) applicationId: string) {
     return await ctx.svc(ApplicationService).reverseWorkflow(applicationId)
   }
@@ -63,7 +63,7 @@ export class ApplicationActionsResolver {
   }
 
   @FieldResolver(returns => Boolean)
-  async reverseWorkflow (@Ctx() ctx: RQContext, @Root() application: Application) {
-    return await ctx.svc(ApplicationService).mayReverseWorkflow(application)
+  reverseWorkflow (@Ctx() ctx: RQContext, @Root() application: Application) {
+    return ctx.svc(ApplicationService).mayReverseWorkflow(application)
   }
 }

--- a/api/src/application/application.resolver.ts
+++ b/api/src/application/application.resolver.ts
@@ -39,7 +39,7 @@ export class ApplicationResolver {
     return application
   }
 
-  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application to the next workflow stage. If phase is READY_FOR_WORKFLOW, moves to the first or next blocking workflow stage. If on the last blocking workflow, moves to REVIEW_COMPLETE. If on the last non-blocking workflow, moves the application to COMPLETE. If all applications are COMPLETE, automatically triggers the app request close mutation.' })
+  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application to the next blocking workflow stage. If phase is READY_FOR_WORKFLOW, moves to the first or next blocking workflow stage. If on the last blocking workflow, moves to REVIEW_COMPLETE. In the non-blocking (WORKFLOW_NONBLOCKING) phase the workflow is non-sequential with all non-blocking requirements editable at once and once they are all resolved this becomes a single "Send to Complete" action that moves the application to COMPLETE.' })
   async advanceWorkflow (@Ctx() ctx: RQContext, @Arg('applicationId', type => ID) applicationId: string) {
     return await ctx.svc(ApplicationService).advanceWorkflow(applicationId)
   }

--- a/api/src/application/application.resolver.ts
+++ b/api/src/application/application.resolver.ts
@@ -44,7 +44,7 @@ export class ApplicationResolver {
     return await ctx.svc(ApplicationService).advanceWorkflow(applicationId)
   }
 
-  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application back to the previous blocking workflow stage. Non-blocking workflow stages are excluded from the reverse order, so this only steps back through the blocking workflow during the review (SUBMITTED) phase. If on the first blocking workflow stage, moves back to APPROVAL.' })
+  @Mutation(returns => ValidatedAppRequestResponse, { description: 'Moves the application back to the previous blocking workflow stage. Non-blocking workflow stages are excluded from the reverse order, so this only steps back through the blocking workflow during the review (SUBMITTED) phase.  If no blocking then moved to APPROVAL' })
   async reverseWorkflow (@Ctx() ctx: RQContext, @Arg('applicationId', type => ID) applicationId: string) {
     return await ctx.svc(ApplicationService).reverseWorkflow(applicationId)
   }

--- a/api/src/application/application.service.ts
+++ b/api/src/application/application.service.ts
@@ -54,8 +54,11 @@ export class ApplicationService extends AuthService<Application> {
 
   async getNextWorkflowStage (application: Application) {
     if (!this.mayAdvanceWorkflow(application)) return null
-    const blocking = application.appRequestPhase !== AppRequestPhase.WORKFLOW_NONBLOCKING
-    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking })
+    // Non-blocking workflow is non-sequential advancing goes straight to complete, so there is no "next stage"
+    // the rest of this only applies to the
+    // blocking workflow.
+    if (application.appRequestPhase === AppRequestPhase.WORKFLOW_NONBLOCKING) return null
+    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: true })
     if (!application.workflowStageKey) return stages[0]
     const currentIndex = stages.findIndex(s => s.key === application.workflowStageKey)
     if (currentIndex === -1 || currentIndex + 1 >= stages.length) return null
@@ -65,7 +68,9 @@ export class ApplicationService extends AuthService<Application> {
   async getPreviousWorkflowStage (application: Application) {
     if (!this.mayReverseWorkflow(application)) return null
     // only blocking workflow stages participate in the reverse order, non-blocking stages are excluded.
-    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: true })
+    // made authoritative for nonBlocking.
+    const stages = (await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: true }))
+      .filter(s => !programRegistry.getWorkflowStageByKey(s.key)?.nonBlocking)
     // past the blocking workflow (REVIEW_COMPLETE, no active stage) reversing re-enters last blocking stage.
     const currentIndex = application.phase === ApplicationPhase.REVIEW_COMPLETE
       ? stages.length
@@ -113,8 +118,10 @@ export class ApplicationService extends AuthService<Application> {
     if (application.phase === ApplicationPhase.READY_FOR_WORKFLOW && !application.workflowStageKey) return false
     if (this.isOwn(application) && !this.hasControl('AppRequest', 'review_own')) return false
     if (!this.hasControl('AppRequest', 'review', application.appRequestTags)) return false
+    // Fix for leak of reverse related to blocking workflow stages that only exist while the request is in the review (SUBMITTED) phase
+    if (application.appRequestPhase !== AppRequestPhase.SUBMITTED) return false
     // exclude non-blocking workflow stages from the reverse order. a reviewer can
-    // never reverse from (or onto) a non-blocking stage, in any AppRequestPhase.  Always open once open
+    // never reverse from (or onto) a non-blocking stage, in any AppRequestPhase.  Always open once open.
     const currentStage = programRegistry.getWorkflowStageByKey(application.workflowStageKey)
     return !currentStage?.nonBlocking
   }

--- a/api/src/application/application.service.ts
+++ b/api/src/application/application.service.ts
@@ -113,9 +113,10 @@ export class ApplicationService extends AuthService<Application> {
     if (application.phase === ApplicationPhase.READY_FOR_WORKFLOW && !application.workflowStageKey) return false
     if (this.isOwn(application) && !this.hasControl('AppRequest', 'review_own')) return false
     if (!this.hasControl('AppRequest', 'review', application.appRequestTags)) return false
-    // Non-blocking workflow stages are excluded from the reverse (return) order. Application-level reversal only
-    // steps back through the blocking workflow.
-    return application.appRequestPhase === AppRequestPhase.SUBMITTED
+    // exclude non-blocking workflow stages from the reverse order. a reviewer can
+    // never reverse from (or onto) a non-blocking stage, in any AppRequestPhase.  Always open once open
+    const currentStage = programRegistry.getWorkflowStageByKey(application.workflowStageKey)
+    return !currentStage?.nonBlocking
   }
 
   async advanceWorkflow (applicationId: string) {

--- a/api/src/application/application.service.ts
+++ b/api/src/application/application.service.ts
@@ -66,8 +66,10 @@ export class ApplicationService extends AuthService<Application> {
     if (!this.mayReverseWorkflow(application)) return null
     // only blocking workflow stages participate in the reverse order, non-blocking stages are excluded.
     const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: true })
-    if (!application.workflowStageKey) return null
-    const currentIndex = stages.findIndex(s => s.key === application.workflowStageKey)
+    // past the blocking workflow (REVIEW_COMPLETE, no active stage) reversing re-enters last blocking stage.
+    const currentIndex = application.phase === ApplicationPhase.REVIEW_COMPLETE
+      ? stages.length
+      : stages.findIndex(s => s.key === application.workflowStageKey)
     if (currentIndex > 0) {
       return stages[currentIndex - 1]
     }

--- a/api/src/application/application.service.ts
+++ b/api/src/application/application.service.ts
@@ -63,10 +63,9 @@ export class ApplicationService extends AuthService<Application> {
   }
 
   async getPreviousWorkflowStage (application: Application) {
-    if (!await this.mayReverseWorkflow(application)) return null
-    const blocking = application.appRequestPhase !== AppRequestPhase.WORKFLOW_NONBLOCKING
-    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking })
-    if (application.phase === ApplicationPhase.COMPLETE) return stages[stages.length - 1]
+    if (!this.mayReverseWorkflow(application)) return null
+    // only blocking workflow stages participate in the reverse order, non-blocking stages are excluded.
+    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: true })
     if (!application.workflowStageKey) return null
     const currentIndex = stages.findIndex(s => s.key === application.workflowStageKey)
     if (currentIndex > 0) {
@@ -105,22 +104,16 @@ export class ApplicationService extends AuthService<Application> {
     return this.hasControl('AppRequest', 'review', application.appRequestTags)
   }
 
-  async mayReverseWorkflow (application: Application) {
+  mayReverseWorkflow (application: Application) {
     if (application.closed || application.appRequestPhase === AppRequestPhase.COMPLETE) return false
-    if (![ApplicationPhase.WORKFLOW_BLOCKING, ApplicationPhase.REVIEW_COMPLETE, ApplicationPhase.COMPLETE, ApplicationPhase.WORKFLOW_NONBLOCKING, ApplicationPhase.READY_FOR_WORKFLOW].includes(application.phase)) return false
+    if (![ApplicationPhase.WORKFLOW_BLOCKING, ApplicationPhase.REVIEW_COMPLETE, ApplicationPhase.READY_FOR_WORKFLOW].includes(application.phase)) return false
     // READY_FOR_WORKFLOW could mean we are at the end of a workflow or at the end of review, if end of review we can't reverse
     if (application.phase === ApplicationPhase.READY_FOR_WORKFLOW && !application.workflowStageKey) return false
     if (this.isOwn(application) && !this.hasControl('AppRequest', 'review_own')) return false
     if (!this.hasControl('AppRequest', 'review', application.appRequestTags)) return false
-    if (application.appRequestPhase === AppRequestPhase.SUBMITTED) return true
-
-    const stages = await this.svc(ProgramService).findWorkflowStagesByPeriodIdAndProgramKey(application.periodId, application.programKey, { hasEnabledRequirements: true, blocking: false })
-    if (application.phase === ApplicationPhase.WORKFLOW_NONBLOCKING && stages[0]?.key === application.workflowStageKey) {
-      // can't reverse from the first non-blocking stage
-      return false
-    }
-
-    return true
+    // Non-blocking workflow stages are excluded from the reverse (return) order. Application-level reversal only
+    // steps back through the blocking workflow.
+    return application.appRequestPhase === AppRequestPhase.SUBMITTED
   }
 
   async advanceWorkflow (applicationId: string) {
@@ -150,7 +143,7 @@ export class ApplicationService extends AuthService<Application> {
   async reverseWorkflow (applicationId: string, stage?: number) {
     const [application] = await getApplications({ ids: [applicationId] })
     if (!application) throw new Error(`Application not found: ${applicationId}`)
-    if (!await this.mayReverseWorkflow(application)) throw new Error('You may not reverse this application to a previous stage.')
+    if (!this.mayReverseWorkflow(application)) throw new Error('You may not reverse this application to a previous stage.')
     await appRequestTransaction(application.appRequestInternalId, async db => {
       await reverseWorkflow(application.id, db)
       await evaluateAppRequest(application.appRequestInternalId, db)

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -247,9 +247,8 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
     }
     const hasUpdate = this.hasControl('PromptAnswer', 'update', { ...prompt.authorizationKeys, ...prompt.appRequestTags })
     const hasUpdateAnytime = this.hasControl('PromptAnswer', 'update_anytime', { ...prompt.authorizationKeys, ...prompt.appRequestTags })
-    // once the request is actually in WORKFLOW_NONBLOCKING or later the normal sequence runs
-    // but this is needed to relax editability for earlier phases for emereged non-blocking workflows.
-    if (prompt.requirementType === RequirementType.WORKFLOW && prompt.appRequestDbPhase !== AppRequestPhase.WORKFLOW_NONBLOCKING) {
+    // non-blocking workflow stages stay editable once their emergence phase is reached for the remainder of the request lifecycle
+    if (prompt.requirementType === RequirementType.WORKFLOW) {
       const stage = programRegistry.getWorkflowStageByKey(prompt.workflowStage)
       const emergence = stage?.nonBlockingEmergence ?? AppRequestPhase.WORKFLOW_NONBLOCKING
       if (stage?.nonBlocking && appRequestPhaseReached(prompt.appRequestDbPhase, emergence)) {

--- a/api/src/prompt/prompt.service.ts
+++ b/api/src/prompt/prompt.service.ts
@@ -7,7 +7,7 @@ import {
   requirementRegistry, AppRequestStatusDB, AppRequest, updateAppRequestData, getAppRequests,
   getAppRequestData, appRequestTransaction, recordAppRequestActivity, appConfig, AppRequestData,
   AppRequestStatus, ApplicationPhase, ApplicationService, setRequirementPromptsInvalid,
-  AppRequestServiceInternal, AppRequestPhase, RequirementType, periodConfigCache, programRegistry,
+  AppRequestServiceInternal, AppRequestPhase, appRequestPhaseReached, RequirementType, periodConfigCache, programRegistry,
   statusVisibleToApplicantPhases, applicantRequirementTypes, setRequirementPromptsValid,
   RQContext,
   RequirementPromptFilter,
@@ -247,6 +247,15 @@ export class RequirementPromptService extends AuthService<RequirementPrompt> {
     }
     const hasUpdate = this.hasControl('PromptAnswer', 'update', { ...prompt.authorizationKeys, ...prompt.appRequestTags })
     const hasUpdateAnytime = this.hasControl('PromptAnswer', 'update_anytime', { ...prompt.authorizationKeys, ...prompt.appRequestTags })
+    // once the request is actually in WORKFLOW_NONBLOCKING or later the normal sequence runs
+    // but this is needed to relax editability for earlier phases for emereged non-blocking workflows.
+    if (prompt.requirementType === RequirementType.WORKFLOW && prompt.appRequestDbPhase !== AppRequestPhase.WORKFLOW_NONBLOCKING) {
+      const stage = programRegistry.getWorkflowStageByKey(prompt.workflowStage)
+      const emergence = stage?.nonBlockingEmergence ?? AppRequestPhase.WORKFLOW_NONBLOCKING
+      if (stage?.nonBlocking && appRequestPhaseReached(prompt.appRequestDbPhase, emergence)) {
+        return hasUpdate || hasUpdateAnytime
+      }
+    }
     if (prompt.appRequestDbPhase === AppRequestPhase.SUBMITTED) {
       if (prompt.requirementType === RequirementType.WORKFLOW) {
         if (prompt.workflowStage === prompt.applicationWorkflowStage) {

--- a/api/src/registry/program.ts
+++ b/api/src/registry/program.ts
@@ -1,4 +1,4 @@
-import { requirementRegistry } from '../internal.js'
+import { AppRequest, AppRequestPhase, requirementRegistry } from '../internal.js'
 
 export interface ProgramDefinition {
   key: string
@@ -45,6 +45,12 @@ export interface WorkflowStage {
    * improvements or training opportunities.
    */
   nonBlocking?: boolean
+  /**
+   * For workflows that are set nonBlocking: true, this property identifies in what AppRequestPhase
+   * these workflow requirements first become visible.  Once visible these workflows remain visible
+   * for the remainder of the AppRequest lifecycle
+   */
+  nonBlockingEmergence: AppRequestPhase
   /**
    * The title of the stage, displayed to the user.
    */

--- a/api/src/registry/program.ts
+++ b/api/src/registry/program.ts
@@ -47,10 +47,12 @@ export interface WorkflowStage {
   nonBlocking?: boolean
   /**
    * For workflows that are set nonBlocking: true, this property identifies in what AppRequestPhase
-   * these workflow requirements first become visible.  Once visible these workflows remain visible
-   * for the remainder of the AppRequest lifecycle
+   * these workflow requirements first become visible/editable.  Once visible these workflows remain visible
+   * for the remainder of the AppRequest lifecycle. Defaults to WORKFLOW_NONBLOCKING,
+   * which preserves the legacy behavior of only surfacing non-blocking workflow requirements once the
+   * request reaches the WORKFLOW_NONBLOCKING phase.
    */
-  nonBlockingEmergence: AppRequestPhase
+  nonBlockingEmergence?: AppRequestPhase
   /**
    * The title of the stage, displayed to the user.
    */

--- a/api/src/registry/program.ts
+++ b/api/src/registry/program.ts
@@ -52,7 +52,7 @@ export interface WorkflowStage {
    * which preserves the legacy behavior of only surfacing non-blocking workflow requirements once the
    * request reaches the WORKFLOW_NONBLOCKING phase.
    */
-  nonBlockingEmergence?: AppRequestPhase
+  nonBlockingEmergence?: AppRequestPhase.SUBMITTED | AppRequestPhase.ACCEPTANCE | AppRequestPhase.WORKFLOW_NONBLOCKING
   /**
    * The title of the stage, displayed to the user.
    */

--- a/demos/src/rc/definitions/models/softwareDevelopment.models.ts
+++ b/demos/src/rc/definitions/models/softwareDevelopment.models.ts
@@ -78,3 +78,12 @@ export const AuditSoftwareRegularPromptSchema = {
   additionalProperties: false
 } as const satisfies SchemaObject
 export type AuditSoftwareRegularPromptData = FromSchema<typeof AuditSoftwareRegularPromptSchema>
+
+export const ReviewSoftwarSecondEyesPromptSchema = {
+  type: 'object',
+  properties: {
+    score: { type: 'number'}
+  },
+  additionalProperties: false
+} as const satisfies SchemaObject
+export type ReviewSoftwarSecondEyesPromptData = FromSchema<typeof ReviewSoftwarSecondEyesPromptSchema>

--- a/demos/src/rc/definitions/models/softwareDevelopment.models.ts
+++ b/demos/src/rc/definitions/models/softwareDevelopment.models.ts
@@ -60,3 +60,21 @@ export const AssessCriticalThinkingSchema = {
   additionalProperties: false
 } as const satisfies SchemaObject
 export type AssessCriticalThinkingPromptData = FromSchema<typeof AssessCriticalThinkingSchema>
+
+export const AuditSoftwareSubmittedPromptSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean'}
+  },
+  additionalProperties: false
+} as const satisfies SchemaObject
+export type AuditSoftwareSubmittedPromptData = FromSchema<typeof AuditSoftwareSubmittedPromptSchema>
+
+export const AuditSoftwareRegularPromptSchema = {
+  type: 'object',
+  properties: {
+    ok: { type: 'boolean'}
+  },
+  additionalProperties: false
+} as const satisfies SchemaObject
+export type AuditSoftwareRegularPromptData = FromSchema<typeof AuditSoftwareRegularPromptSchema>

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -1,4 +1,4 @@
-import type { ProgramDefinition } from '@reqquest/api'
+import { ProgramDefinition, AppRequestPhase } from '@reqquest/api'
 
 const operationsInfrastructure: ProgramDefinition = {
   key: 'operations_infrastructure',
@@ -28,7 +28,20 @@ const softwareDevelopment: ProgramDefinition = {
     'assess_critical_thinking_req',
     'reccomendation_letter_req',
     'assess_reccomendation_lettern_req'
-  ]
+  ],
+  workfworkflowStages: [{
+    key: 'software_development_non_blocking_show_submitted',
+    nonBlocking: true,
+    nonBlockingEmergence: AppRequestPhase.SUBMITTED,
+    title: 'Audit the actively ongoing review',
+    requirementKeys: ['approve_reviewer_exercise_exemption_workflow_req']
+  },
+  {
+    key: 'software_development_non_blocking_show_regular',
+    nonBlocking: true,
+    title: 'Audit the entire program after all other phases complete',
+    requirementKeys: ['approve_reviewer_exercise_exemption_workflow_req']
+  }]
 }
 const projectManagement: ProgramDefinition = {
   key: 'project_management',

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -34,13 +34,13 @@ const softwareDevelopment: ProgramDefinition = {
     nonBlocking: true,
     nonBlockingEmergence: AppRequestPhase.SUBMITTED,
     title: 'Audit the actively ongoing review',
-    requirementKeys: ['approve_reviewer_exercise_exemption_workflow_req']
+    requirementKeys: ['audit_software_development_non_blocking_show_submitted']
   },
   {
     key: 'software_development_non_blocking_show_regular',
     nonBlocking: true,
     title: 'Audit the entire program after all other phases complete',
-    requirementKeys: ['approve_reviewer_exercise_exemption_workflow_req']
+    requirementKeys: ['audit_software_development_non_blocking_show_regular']
   }]
 }
 const projectManagement: ProgramDefinition = {

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -29,18 +29,19 @@ const softwareDevelopment: ProgramDefinition = {
     'reccomendation_letter_req',
     'assess_reccomendation_lettern_req'
   ],
-  workfworkflowStages: [{
+  workflowStages: [
+  {
     key: 'software_development_non_blocking_show_submitted',
     nonBlocking: true,
     nonBlockingEmergence: AppRequestPhase.SUBMITTED,
     title: 'Audit the actively ongoing review',
-    requirementKeys: ['audit_software_development_non_blocking_show_submitted']
+    requirementKeys: ['audit_software_development_non_blocking_show_submitted_req']
   },
   {
     key: 'software_development_non_blocking_show_regular',
     nonBlocking: true,
     title: 'Audit the entire program after all other phases complete',
-    requirementKeys: ['audit_software_development_non_blocking_show_regular']
+    requirementKeys: ['audit_software_development_non_blocking_show_regular_req']
   }]
 }
 const projectManagement: ProgramDefinition = {

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -31,6 +31,12 @@ const softwareDevelopment: ProgramDefinition = {
   ],
   workflowStages: [
   {
+    key: 'software_development_blocking_second_eyes',
+    nonBlocking: false,
+    title: 'Second reviewer assessment',
+    requirementKeys: ['reviewer_software_development_second_eyes_req']
+  },
+  {
     key: 'software_development_non_blocking_show_submitted',
     nonBlocking: true,
     nonBlockingEmergence: AppRequestPhase.SUBMITTED,

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -44,6 +44,13 @@ const softwareDevelopment: ProgramDefinition = {
     requirementKeys: ['audit_software_development_non_blocking_show_submitted_req']
   },
   {
+    key: 'software_development_non_blocking_show_submitted2',
+    nonBlocking: true,
+    nonBlockingEmergence: AppRequestPhase.SUBMITTED,
+    title: 'Audit the actively ongoing review for a second time',
+    requirementKeys: ['audit_software_development_non_blocking_show_submitted_req2']
+  },
+  {
     key: 'software_development_non_blocking_show_regular',
     nonBlocking: true,
     title: 'Audit the entire program after all other phases complete',

--- a/demos/src/rc/definitions/programs.ts
+++ b/demos/src/rc/definitions/programs.ts
@@ -55,6 +55,12 @@ const softwareDevelopment: ProgramDefinition = {
     nonBlocking: true,
     title: 'Audit the entire program after all other phases complete',
     requirementKeys: ['audit_software_development_non_blocking_show_regular_req']
+  },
+  {
+    key: 'software_development_non_blocking_show_regular2',
+    nonBlocking: true,
+    title: 'Audit the entire program again after all other phases complete',
+    requirementKeys: ['audit_software_development_non_blocking_show_regular_req2']
   }]
 }
 const projectManagement: ProgramDefinition = {

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -1,6 +1,6 @@
 import { PromptDefinition } from '@reqquest/api'
 import { MutationMessageType } from '@txstate-mws/graphql-server'
-import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, AuditSoftwareRegularPromptData, AuditSoftwareRegularPromptSchema, AuditSoftwareSubmittedPromptData, AuditSoftwareSubmittedPromptSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema } from '../models/index.js'
+import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, AuditSoftwareRegularPromptData, AuditSoftwareRegularPromptSchema, AuditSoftwareSubmittedPromptData, AuditSoftwareSubmittedPromptSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema, ReviewSoftwarSecondEyesPromptData, ReviewSoftwarSecondEyesPromptSchema } from '../models/index.js'
 import { fileHandler } from 'fastify-txstate'
 import { OptOutData, OptOutSchema } from '../models/optOut.models.js'
 
@@ -136,6 +136,20 @@ export const audit_software_development_non_blocking_show_regular_prompt: Prompt
     const messages = []
     if (data.ok == null) {
       messages.push({ type: MutationMessageType.error, message: 'Please answer if review was performed appropriately.', arg: 'ok' })
+    }
+    return messages
+  }
+}
+
+export const reviewer_software_development_second_eyes_prompt: PromptDefinition<ReviewSoftwarSecondEyesPromptData> = {
+  key: 'reviewer_software_development_second_eyes_prompt',
+  title: 'Second review score',
+  description: 'Second review score',
+  schema: ReviewSoftwarSecondEyesPromptSchema,
+  validate: (data, config) => {
+    const messages = []
+    if (data.score == null || data.score > 100 || data.score < 0) {
+      messages.push({ type: MutationMessageType.error, message: 'Please provide an overall score from 0 to 100.', arg: 'score' })
     }
     return messages
   }

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -1,6 +1,6 @@
 import { PromptDefinition } from '@reqquest/api'
 import { MutationMessageType } from '@txstate-mws/graphql-server'
-import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, AuditSoftwareSubmittedPromptData, AuditSoftwareSubmittedPromptSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema } from '../models/index.js'
+import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, AuditSoftwareRegularPromptData, AuditSoftwareRegularPromptSchema, AuditSoftwareSubmittedPromptData, AuditSoftwareSubmittedPromptSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema } from '../models/index.js'
 import { fileHandler } from 'fastify-txstate'
 import { OptOutData, OptOutSchema } from '../models/optOut.models.js'
 
@@ -118,6 +118,20 @@ export const audit_software_development_non_blocking_show_submitted_prompt: Prom
   title: 'Audit during review',
   description: 'Audit during review',
   schema: AuditSoftwareSubmittedPromptSchema,
+  validate: (data, config) => {
+    const messages = []
+    if (data.ok == null) {
+      messages.push({ type: MutationMessageType.error, message: 'Please answer if review was performed appropriately during review.', arg: 'ok' })
+    }
+    return messages
+  }
+}
+
+export const audit_software_development_non_blocking_show_regular_prompt: PromptDefinition<AuditSoftwareRegularPromptData> = {
+  key: 'audit_software_development_non_blocking_show_regular_prompt',
+  title: 'Audit regular',
+  description: 'Audit regular',
+  schema: AuditSoftwareRegularPromptSchema,
   validate: (data, config) => {
     const messages = []
     if (data.ok == null) {

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -127,6 +127,20 @@ export const audit_software_development_non_blocking_show_submitted_prompt: Prom
   }
 }
 
+export const audit_software_development_non_blocking_show_submitted_prompt2: PromptDefinition<AuditSoftwareSubmittedPromptData> = {
+  key: 'audit_software_development_non_blocking_show_submitted_prompt2',
+  title: 'Second audit during review',
+  description: 'Second audit during review',
+  schema: AuditSoftwareSubmittedPromptSchema,
+  validate: (data, config) => {
+    const messages = []
+    if (data.ok == null) {
+      messages.push({ type: MutationMessageType.error, message: 'Please confirm your previous answer if review was performed appropriately during review.', arg: 'ok' })
+    }
+    return messages
+  }
+}
+
 export const audit_software_development_non_blocking_show_regular_prompt: PromptDefinition<AuditSoftwareRegularPromptData> = {
   key: 'audit_software_development_non_blocking_show_regular_prompt',
   title: 'Audit regular',

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -1,6 +1,6 @@
 import { PromptDefinition } from '@reqquest/api'
 import { MutationMessageType } from '@txstate-mws/graphql-server'
-import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema } from '../models/index.js'
+import { AssessCriticalThinkingPromptData, AssessCriticalThinkingSchema, AssessOutsideClassExamplePromptData, AssessOutsideClassExampleSchema, AssessPuzzleSolutionPromptData, AssessPuzzleSolutionSchema, AuditSoftwareSubmittedPromptData, AuditSoftwareSubmittedPromptSchema, CriticalThinkingPromptData, CriticalThinkingSchema, DataRelatedPuzzlePromptData, DataRelatedPuzzleSchema, OutsideClassExamplePromptData, OutsideClassExampleSchema } from '../models/index.js'
 import { fileHandler } from 'fastify-txstate'
 import { OptOutData, OptOutSchema } from '../models/optOut.models.js'
 
@@ -108,6 +108,20 @@ export const assess_critical_thinking_prompt: PromptDefinition<AssessCriticalThi
     }
     if (data.realIssue == null) {
       messages.push({ type: MutationMessageType.error, message: 'Please answer the question.', arg: 'realIssue' })
+    }
+    return messages
+  }
+}
+
+export const audit_software_development_non_blocking_show_submitted_prompt: PromptDefinition<AuditSoftwareSubmittedPromptData> = {
+  key: 'audit_software_development_non_blocking_show_submitted_prompt',
+  title: 'Audit during review',
+  description: 'Audit during review',
+  schema: AuditSoftwareSubmittedPromptSchema,
+  validate: (data, config) => {
+    const messages = []
+    if (data.ok == null) {
+      messages.push({ type: MutationMessageType.error, message: 'Please answer if review was performed appropriately.', arg: 'ok' })
     }
     return messages
   }

--- a/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
+++ b/demos/src/rc/definitions/prompts/softwareDevelopment.prompts.ts
@@ -155,6 +155,20 @@ export const audit_software_development_non_blocking_show_regular_prompt: Prompt
   }
 }
 
+export const audit_software_development_non_blocking_show_regular_prompt2: PromptDefinition<AuditSoftwareRegularPromptData> = {
+  key: 'audit_software_development_non_blocking_show_regular_prompt2',
+  title: 'Second audit regular',
+  description: 'Second audit regular',
+  schema: AuditSoftwareRegularPromptSchema,
+  validate: (data, config) => {
+    const messages = []
+    if (data.ok == null) {
+      messages.push({ type: MutationMessageType.error, message: 'Please answer if review was performed appropriately AGAIN.', arg: 'ok' })
+    }
+    return messages
+  }
+}
+
 export const reviewer_software_development_second_eyes_prompt: PromptDefinition<ReviewSoftwarSecondEyesPromptData> = {
   key: 'reviewer_software_development_second_eyes_prompt',
   title: 'Second review score',

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -117,6 +117,20 @@ export const audit_software_development_non_blocking_show_submitted_req: Require
   }
 }
 
+export const audit_software_development_non_blocking_show_submitted_req2: RequirementDefinition = {
+  type: RequirementType.WORKFLOW,
+  key: 'audit_software_development_non_blocking_show_submitted_req2',
+  title: 'Second audit during review ',
+  navTitle: 'Second audit during review',
+  description: 'Second audit during review',
+  promptKeys: ['audit_software_development_non_blocking_show_submitted_prompt2'],
+  resolve: (data, config) => {
+    const audit = data['audit_software_development_non_blocking_show_submitted_prompt2'] as AuditSoftwareSubmittedPromptData
+    if (audit?.ok == null) return { status: RequirementStatus.PENDING }
+    return { status: RequirementStatus.MET }
+  }
+}
+
 export const audit_software_development_non_blocking_show_regular_req: RequirementDefinition = {
   type: RequirementType.WORKFLOW,
   key: 'audit_software_development_non_blocking_show_regular_req',

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -1,5 +1,5 @@
 import { RequirementDefinition, RequirementStatus, RequirementType } from '@reqquest/api'
-import { DataRelatedPuzzlePromptData, AssessPuzzleSolutionPromptData, OutsideClassExamplePromptData, AssessOutsideClassExamplePromptData, CriticalThinkingPromptData, AssessCriticalThinkingPromptData } from '../models'
+import { DataRelatedPuzzlePromptData, AssessPuzzleSolutionPromptData, OutsideClassExamplePromptData, AssessOutsideClassExamplePromptData, CriticalThinkingPromptData, AssessCriticalThinkingPromptData, AuditSoftwareSubmittedPromptData, AuditSoftwareRegularPromptData } from '../models'
 import { OptOutData } from '../models/optOut.models'
 
 export const software_dev_opt_out_req: RequirementDefinition = {
@@ -99,6 +99,34 @@ export const assess_critical_thinking_req: RequirementDefinition = {
     const writtenAutomationData = data['assess_critical_thinking_prompt'] as AssessCriticalThinkingPromptData
     if (writtenAutomationData?.feasable == null) return { status: RequirementStatus.PENDING }
     if (writtenAutomationData?.realIssue == null) return { status: RequirementStatus.PENDING }
+    return { status: RequirementStatus.MET }
+  }
+}
+
+export const audit_software_development_non_blocking_show_submitted_req: RequirementDefinition = {
+  type: RequirementType.WORKFLOW,
+  key: 'audit_software_development_non_blocking_show_submitted_req',
+  title: 'Audit during review',
+  navTitle: 'Audit during review',
+  description: 'Audit during review',
+  promptKeys: ['audit_software_development_non_blocking_show_submitted_prompt'],
+  resolve: (data, config) => {
+    const audit = data['audit_software_development_non_blocking_show_submitted_prompt'] as AuditSoftwareSubmittedPromptData
+    if (audit?.ok == null) return { status: RequirementStatus.PENDING }
+    return { status: RequirementStatus.MET }
+  }
+}
+
+export const audit_software_development_non_blocking_show_regular_req: RequirementDefinition = {
+  type: RequirementType.WORKFLOW,
+  key: 'audit_software_development_non_blocking_show_regular_req',
+  title: 'Audit regular`',
+  navTitle: 'Audit regular',
+  description: 'Audit regular',
+  promptKeys: ['audit_software_development_non_blocking_show_regular_prompt'],
+  resolve: (data, config) => {
+    const audit = data['audit_software_development_non_blocking_show_regular_prompt'] as AuditSoftwareRegularPromptData
+    if (audit?.ok == null) return { status: RequirementStatus.PENDING }
     return { status: RequirementStatus.MET }
   }
 }

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -145,6 +145,20 @@ export const audit_software_development_non_blocking_show_regular_req: Requireme
   }
 }
 
+export const audit_software_development_non_blocking_show_regular_req2: RequirementDefinition = {
+  type: RequirementType.WORKFLOW,
+  key: 'audit_software_development_non_blocking_show_regular_req2',
+  title: 'Second audit regular`',
+  navTitle: 'Second audit regular',
+  description: 'Second audit regular',
+  promptKeys: ['audit_software_development_non_blocking_show_regular_prompt2'],
+  resolve: (data, config) => {
+    const audit = data['audit_software_development_non_blocking_show_regular_prompt2'] as AuditSoftwareRegularPromptData
+    if (audit?.ok == null) return { status: RequirementStatus.PENDING }
+    return { status: RequirementStatus.MET }
+  }
+}
+
 export const reviewer_software_development_second_eyes_req: RequirementDefinition = {
   type: RequirementType.WORKFLOW,
   key: 'reviewer_software_development_second_eyes_req',

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -1,5 +1,5 @@
 import { RequirementDefinition, RequirementStatus, RequirementType } from '@reqquest/api'
-import { DataRelatedPuzzlePromptData, AssessPuzzleSolutionPromptData, OutsideClassExamplePromptData, AssessOutsideClassExamplePromptData, CriticalThinkingPromptData, AssessCriticalThinkingPromptData, AuditSoftwareSubmittedPromptData, AuditSoftwareRegularPromptData } from '../models'
+import { DataRelatedPuzzlePromptData, AssessPuzzleSolutionPromptData, OutsideClassExamplePromptData, AssessOutsideClassExamplePromptData, CriticalThinkingPromptData, AssessCriticalThinkingPromptData, AuditSoftwareSubmittedPromptData, AuditSoftwareRegularPromptData, ReviewSoftwarSecondEyesPromptData } from '../models'
 import { OptOutData } from '../models/optOut.models'
 
 export const software_dev_opt_out_req: RequirementDefinition = {
@@ -127,6 +127,20 @@ export const audit_software_development_non_blocking_show_regular_req: Requireme
   resolve: (data, config) => {
     const audit = data['audit_software_development_non_blocking_show_regular_prompt'] as AuditSoftwareRegularPromptData
     if (audit?.ok == null) return { status: RequirementStatus.PENDING }
+    return { status: RequirementStatus.MET }
+  }
+}
+
+export const reviewer_software_development_second_eyes_req: RequirementDefinition = {
+  type: RequirementType.WORKFLOW,
+  key: 'reviewer_software_development_second_eyes_req',
+  title: 'Second reviewer score`',
+  navTitle: 'Second reviewer score',
+  description: 'Second reviewer score',
+  promptKeys: ['reviewer_software_development_second_eyes_prompt'],
+  resolve: (data, config) => {
+    const secondEyes = data['reviewer_software_development_second_eyes_prompt'] as ReviewSoftwarSecondEyesPromptData
+    if (secondEyes?.score == null) return { status: RequirementStatus.PENDING }
     return { status: RequirementStatus.MET }
   }
 }

--- a/ui/src/local/default/YardPrompt.svelte
+++ b/ui/src/local/default/YardPrompt.svelte
@@ -5,7 +5,8 @@
   import { QuestionnairePrompt } from '$lib'
   export let data
   export let prestageData
-  data.__prestage = prestageData.latest ?? prestageData.current
+  $: prestage = prestageData.latest ?? prestageData.current
+  $: if (data) data.__prestage = prestage
 </script>
 
   <QuestionnairePrompt externalLinks={[{ url: 'https://www.aspca.org/', label: 'Yard Safety Tips from ASPCA' }, { url: 'https://www.humanesociety.org/', label: 'Creating a Pet-Friendly Yard from Humane Society' }]} title="Yard Information." description="Please provide some information about your yard to help us ensure it's a safe environment for your new pet.">

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -167,6 +167,8 @@ import RCAuditSoftwareDevelopmentRegular from './rc/AuditSoftwareDevelopmentRegu
 import RCAuditSoftwareDevelopmentRegularDisplay from './rc/AuditSoftwareDevelopmentRegularDisplay.svelte'
 import RCAuditSoftwareDevelopmentSubmitted from './rc/AuditSoftwareDevelopmentSubmitted.svelte'
 import RCAuditSoftwareDevelopmentSubmittedDisplay from './rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte'
+import RCReviewerSoftwareDevelopmentSecondEyes from './rc/ReviewerSoftwareDevelopmentSecondEyes.svelte'
+import RCReviewerSoftwareDevelopmentSecondEyesDisplay from './rc/ReviewerSoftwareDevelopmentSecondEyesDisplay.svelte'
 
 import { api } from '$internal/api'
 
@@ -454,7 +456,8 @@ function configureDemoInstanceParams () {
         { key: 'reccomendation_letter_req' },
         { key: 'assess_reccomendation_letter_req' },
         { key: 'audit_software_development_non_blocking_show_submitted_req'},
-        { key: 'audit_software_development_non_blocking_show_regular_req'}
+        { key: 'audit_software_development_non_blocking_show_regular_req'},
+        { key: 'reviewer_software_development_second_eyes_req'}
       ],
       prompts: [{
         key: 'pre_qual_prompt',
@@ -612,6 +615,11 @@ function configureDemoInstanceParams () {
         key: 'audit_software_development_non_blocking_show_regular_prompt',
         formComponent: RCAuditSoftwareDevelopmentRegular,
         displayComponent: RCAuditSoftwareDevelopmentRegularDisplay
+      },
+      {
+        key: 'reviewer_software_development_second_eyes_prompt',
+        formComponent: RCReviewerSoftwareDevelopmentSecondEyes,
+        displayComponent: RCReviewerSoftwareDevelopmentSecondEyesDisplay
       }
       ]
     }

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -171,6 +171,8 @@ import RCAuditSoftwareDevelopmentSubmitted2 from './rc/AuditSoftwareDevelopmentS
 import RCAuditSoftwareDevelopmentSubmittedDisplay2 from './rc/AuditSoftwareDevelopmentSubmittedDisplay2.svelte'
 import RCReviewerSoftwareDevelopmentSecondEyes from './rc/ReviewerSoftwareDevelopmentSecondEyes.svelte'
 import RCReviewerSoftwareDevelopmentSecondEyesDisplay from './rc/ReviewerSoftwareDevelopmentSecondEyesDisplay.svelte'
+import RCAuditSoftwareDevelopmentRegular2 from './rc/AuditSoftwareDevelopmentRegular2.svelte'
+import RCAuditSoftwareDevelopmentRegularDisplay2 from './rc/AuditSoftwareDevelopmentRegularDisplay2.svelte'
 
 import { api } from '$internal/api'
 
@@ -460,6 +462,7 @@ function configureDemoInstanceParams () {
         { key: 'audit_software_development_non_blocking_show_submitted_req'},
         { key: 'audit_software_development_non_blocking_show_submitted_req2'},
         { key: 'audit_software_development_non_blocking_show_regular_req'},
+        { key: 'audit_software_development_non_blocking_show_regular_req2'},
         { key: 'reviewer_software_development_second_eyes_req'}
       ],
       prompts: [{
@@ -623,6 +626,11 @@ function configureDemoInstanceParams () {
         key: 'audit_software_development_non_blocking_show_regular_prompt',
         formComponent: RCAuditSoftwareDevelopmentRegular,
         displayComponent: RCAuditSoftwareDevelopmentRegularDisplay
+      },
+      {
+        key: 'audit_software_development_non_blocking_show_regular_prompt2',
+        formComponent: RCAuditSoftwareDevelopmentRegular2,
+        displayComponent: RCAuditSoftwareDevelopmentRegularDisplay2
       },
       {
         key: 'reviewer_software_development_second_eyes_prompt',

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -163,6 +163,11 @@ import RCPreQualUserInfoPromptDisplay from './rc/PreQualUserInfoPromptDisplay.sv
 import OptOut from './rc/OptOut.svelte'
 import OptOutDisplay from './rc/OptOutDisplay.svelte'
 import RCIntroPanelDefaultSlot from './rc/IntroPanelDefaultSlot.svelte'
+import RCAuditSoftwareDevelopmentRegular from './rc/AuditSoftwareDevelopmentRegular.svelte'
+import RCAuditSoftwareDevelopmentRegularDisplay from './rc/AuditSoftwareDevelopmentRegularDisplay.svelte'
+import RCAuditSoftwareDevelopmentSubmitted from './rc/AuditSoftwareDevelopmentSubmitted.svelte'
+import RCAuditSoftwareDevelopmentSubmittedDisplay from './rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte'
+
 import { api } from '$internal/api'
 
 const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, applicantReview, programs, requirements, prompts, userLookup, slots } = configureDemoInstanceParams()
@@ -447,7 +452,9 @@ function configureDemoInstanceParams () {
         { key: 'organization_req' },
         { key: 'assess_organization_req' },
         { key: 'reccomendation_letter_req' },
-        { key: 'assess_reccomendation_letter_req' }
+        { key: 'assess_reccomendation_letter_req' },
+        { key: 'audit_software_development_non_blocking_show_submitted_req'},
+        { key: 'audit_software_development_non_blocking_show_regular_req'}
       ],
       prompts: [{
         key: 'pre_qual_prompt',
@@ -595,6 +602,16 @@ function configureDemoInstanceParams () {
         key: 'project_management_opt_out_prompt',
         formComponent: OptOut,
         displayComponent: OptOutDisplay
+      },
+      {
+        key: 'audit_software_development_non_blocking_show_submitted_prompt',
+        formComponent: RCAuditSoftwareDevelopmentSubmitted,
+        displayComponent: RCAuditSoftwareDevelopmentSubmittedDisplay
+      },
+      {
+        key: 'audit_software_development_non_blocking_show_regular_prompt',
+        formComponent: RCAuditSoftwareDevelopmentRegular,
+        displayComponent: RCAuditSoftwareDevelopmentRegularDisplay
       }
       ]
     }

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -167,6 +167,8 @@ import RCAuditSoftwareDevelopmentRegular from './rc/AuditSoftwareDevelopmentRegu
 import RCAuditSoftwareDevelopmentRegularDisplay from './rc/AuditSoftwareDevelopmentRegularDisplay.svelte'
 import RCAuditSoftwareDevelopmentSubmitted from './rc/AuditSoftwareDevelopmentSubmitted.svelte'
 import RCAuditSoftwareDevelopmentSubmittedDisplay from './rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte'
+import RCAuditSoftwareDevelopmentSubmitted2 from './rc/AuditSoftwareDevelopmentSubmitted2.svelte'
+import RCAuditSoftwareDevelopmentSubmittedDisplay2 from './rc/AuditSoftwareDevelopmentSubmittedDisplay2.svelte'
 import RCReviewerSoftwareDevelopmentSecondEyes from './rc/ReviewerSoftwareDevelopmentSecondEyes.svelte'
 import RCReviewerSoftwareDevelopmentSecondEyesDisplay from './rc/ReviewerSoftwareDevelopmentSecondEyesDisplay.svelte'
 
@@ -456,6 +458,7 @@ function configureDemoInstanceParams () {
         { key: 'reccomendation_letter_req' },
         { key: 'assess_reccomendation_letter_req' },
         { key: 'audit_software_development_non_blocking_show_submitted_req'},
+        { key: 'audit_software_development_non_blocking_show_submitted_req2'},
         { key: 'audit_software_development_non_blocking_show_regular_req'},
         { key: 'reviewer_software_development_second_eyes_req'}
       ],
@@ -610,6 +613,11 @@ function configureDemoInstanceParams () {
         key: 'audit_software_development_non_blocking_show_submitted_prompt',
         formComponent: RCAuditSoftwareDevelopmentSubmitted,
         displayComponent: RCAuditSoftwareDevelopmentSubmittedDisplay
+      },
+      {
+        key: 'audit_software_development_non_blocking_show_submitted_prompt2',
+        formComponent: RCAuditSoftwareDevelopmentSubmitted2,
+        displayComponent: RCAuditSoftwareDevelopmentSubmittedDisplay2
       },
       {
         key: 'audit_software_development_non_blocking_show_regular_prompt',

--- a/ui/src/local/rc/AuditSoftwareDevelopmentRegular.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentRegular.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FieldRadio } from '@txstate-mws/carbon-svelte'
+</script>
+
+<FieldRadio boolean path="ok" legendText="Does the software development review seem alright during the regular non blocking workflow phase?" items={[{ label: 'Yes', value: true }, { label: 'No', value: false }]} />
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentRegular2.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentRegular2.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FieldRadio } from '@txstate-mws/carbon-svelte'
+</script>
+
+<FieldRadio boolean path="ok" legendText="For the second time, does the software development review seem alright during the regular non blocking workflow phase?" items={[{ label: 'Yes', value: true }, { label: 'No', value: false }]} />
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let data
 </script>
-<p class="text-sm">Does the software development review seem alright during the regular non blocking workflow phase?</p>
+<p class="text-sm">Does the software development review seem alright during the regular non blocking workflow phase</p>
 <p>{data?.ok ? 'Yes' : 'No'}</p>
 

--- a/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data
+</script>
+<p class="text-sm">Does the software development review seem alright during the regular non blocking workflow phase?</p>
+<p>{data?.ok ? 'Yes' : 'No'}</p>
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay2.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentRegularDisplay2.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data
+</script>
+<p class="text-sm">For the second time, does the software development review seem alright during the regular non blocking workflow phase</p>
+<p>{data?.ok ? 'Yes' : 'No'}</p>
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentSubmitted.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentSubmitted.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FieldRadio } from '@txstate-mws/carbon-svelte'
+</script>
+
+<FieldRadio boolean path="ok" legendText="Does the software development review seem alright during the active review phase?" items={[{ label: 'Yes', value: true }, { label: 'No', value: false }]} />
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentSubmitted2.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentSubmitted2.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FieldRadio } from '@txstate-mws/carbon-svelte'
+</script>
+
+<FieldRadio boolean path="ok" legendText="Does the software development review still, for the second time, seem alright during the active review phase?" items={[{ label: 'Yes', value: true }, { label: 'No', value: false }]} />
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data
+</script>
+<p class="text-sm">Does the software development review seem alright during the active review phase?</p>
+<p>{data?.ok ? 'Yes' : 'No'}</p>
+

--- a/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let data
 </script>
-<p class="text-sm">Does the software development review seem alright during the active review phase?</p>
+<p class="text-sm">Does the software development review seem alright during the active review phase</p>
 <p>{data?.ok ? 'Yes' : 'No'}</p>
 

--- a/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay2.svelte
+++ b/ui/src/local/rc/AuditSoftwareDevelopmentSubmittedDisplay2.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data
+</script>
+<p class="text-sm">Does the software development review seem still, for the second time, seem alright</p>
+<p>{data?.ok ? 'Yes' : 'No'}</p>
+

--- a/ui/src/local/rc/PreQualDisplay.svelte
+++ b/ui/src/local/rc/PreQualDisplay.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-    import { booleanToWord } from "$internal"
-  import type { RCPreQual } from "./types"
-
-  export let data: RCPreQual
+  import { booleanToWord } from "$internal"
+  export let data
 </script>
 <p>Aknowledged expectaitions: {booleanToWord(data.acknowledgeExpectations)}</p>
 <p>Availabile: {booleanToWord(data.availability)}</p>
+<p>LSAT: {data.__prestage.nodes.client.data.lsat}</p>
 <p>GPA: {data?.gpa}</p>
 
 

--- a/ui/src/local/rc/PreQualPrompt.svelte
+++ b/ui/src/local/rc/PreQualPrompt.svelte
@@ -5,7 +5,7 @@
   export let data: Partial<RCPreQual>
   export let prestageData
   $: prestage = prestageData.latest ?? prestageData.current
-  $: data.__prestage = prestage
+  $: if (data) data.__prestage = prestage
 </script>
 
 <!--<FieldNumber labelText='LSAT Score' path='data.__prestage.nodes.client.data.lsat' readonly defaultValue={prestage.nodes.client.data.lsat} />-->

--- a/ui/src/local/rc/PreQualUserInfoPrompt.svelte
+++ b/ui/src/local/rc/PreQualUserInfoPrompt.svelte
@@ -3,7 +3,7 @@
   export let data
   export let prestageData
   $: prestage = prestageData.latest ?? prestageData.current
-    $: if (data) data.__prestage = prestage
+  $: if (data) data.__prestage = prestage
 
   const options = [
     { value: true, label: "Yes" },

--- a/ui/src/local/rc/PreQualUserInfoPrompt.svelte
+++ b/ui/src/local/rc/PreQualUserInfoPrompt.svelte
@@ -3,7 +3,7 @@
   export let data
   export let prestageData
   $: prestage = prestageData.latest ?? prestageData.current
-  $: data.__prestage = prestage
+    $: if (data) data.__prestage = prestage
 
   const options = [
     { value: true, label: "Yes" },

--- a/ui/src/local/rc/PreQualUserInfoPromptDisplay.svelte
+++ b/ui/src/local/rc/PreQualUserInfoPromptDisplay.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 export let data
-export let prestageData
-$: prestage = prestageData.latest ?? prestageData.current
 </script>
 
-<p>NetID: {prestage.nodes.client.data.netid}</p>
-<p>Name: {prestage.nodes.client.data.name}</p>
-<p>Email: {prestage.nodes.client.data.email}</p>
+<p>NetID: {data.__prestage.nodes.client.data.netid}</p>
+<p>Name: {data.__prestage.nodes.client.data.name}</p>
+<p>Email: {data.__prestage.nodes.client.data.email}</p>
 <p>Information is correct: {data.correct ? 'Yes' : 'No'}</p>
 
 

--- a/ui/src/local/rc/ReviewerSoftwareDevelopmentSecondEyes.svelte
+++ b/ui/src/local/rc/ReviewerSoftwareDevelopmentSecondEyes.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { FieldNumber } from '@txstate-mws/carbon-svelte'
+</script>
+<FieldNumber path='score' labelText='Overall software development score' max={100} min={0} />
+

--- a/ui/src/local/rc/ReviewerSoftwareDevelopmentSecondEyesDisplay.svelte
+++ b/ui/src/local/rc/ReviewerSoftwareDevelopmentSecondEyesDisplay.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let data
+</script>
+<p class="text-sm">Overall software development score</p>
+<p>{data?.score}</p>
+


### PR DESCRIPTION
https://github.com/txstate-etc/reqquest-txstate/issues/402

Issue:

Currently non-blocking workflows only show post REVIEW and ACCEPTANCE (if exists). For VA-cert these operations need to occur within the review phase as some programs eligibility may be determined early (quickly) while others may be delayed for some time. Holding completion of all applications before allowing any of these operations to process is not feasible.

Solution:

Implement a new emergent flag for nonBlocking workflows that result in these requirements being exposed at earlier appRequestPhases than traditional non-blocking workflow phase. This will allow review/process resources the ability to start performing administrative/audit/back-office operations on a per application basis and not be required to wait until all applications have been moved out of the review and/or acceptance phase.