### PR TITLE
Bug resolution for review dashboard not moving through to

### DIFF
--- a/ui/src/routes/dashboards/reviewer/+page.svelte
+++ b/ui/src/routes/dashboards/reviewer/+page.svelte
@@ -4,9 +4,9 @@
   import DocExport from 'carbon-icons-svelte/lib/DocumentExport.svelte'
   import View from 'carbon-icons-svelte/lib/View.svelte'
   import { DateTime } from 'luxon'
-  import { onMount } from 'svelte'
+  import { onMount, tick } from 'svelte'
   import { toQuery } from 'txstate-utils'
-   import { goto } from '$app/navigation'
+  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { api, REVIEWER_STATUS_CONFIG } from '$internal'
   import type { PageData } from './$types'
@@ -108,7 +108,13 @@
       {
         label: 'View',
         icon: View,
-        onClick: () => { goto(`/requests/${r.id}/approve`) }
+        // Heisenbug :) Resolved after console dumps slowed it down and worked.
+        // defer navigation one tick past the click's synchronous handling. goto() inside the handler
+        // raced with the action button's click and got dropped on the first uncached click after a fresh page load, required second click to navigate.
+        onClick: async () => {
+          await tick()
+          await goto(resolve(`/requests/${r.id}/approve`))
+        }
       }
     ]}
   >

--- a/ui/src/routes/requests/[id]/approve/[programKey]/+page.ts
+++ b/ui/src/routes/requests/[id]/approve/[programKey]/+page.ts
@@ -10,6 +10,5 @@ export const load: PageLoad = async ({ params, depends }) => {
   const coalescedAppRequest = coalesceAppRequestPrompts(appRequest, inlinePromptsWithData)
   if (!coalescedAppRequest) throw error(404, 'App Request not found')
   depends('request:approve')
-  console.log(coalescedAppRequest)
   return { appRequest: coalescedAppRequest, programKey: params.programKey }
 }


### PR DESCRIPTION
ISSUE

When Continue is clicked on ApplicantPromptPage and triggers onSaved method, invalidate was being called on the entire flow before navigation was triggered.  Resulted in prompt.answered being wiped and resulted in user staying on current page.  Page was working off stale data

SOLUTION

ApplicantPromptPage onSave + continueAfterSave was updated to use a new invalidation key that is only to accommodate answered and nav updates, but not reload the entire ApplicantPromptPage so decisions weren't based on stale data. 