### PR TITLE
GitHub dropped PR from Last Thursday: Bug stale state app prompt page  main

### DIFF
--- a/demos/src/rc/definitions/requirements/applicationManagement.requirements.ts
+++ b/demos/src/rc/definitions/requirements/applicationManagement.requirements.ts
@@ -10,7 +10,7 @@ export const application_management_opt_out_req: RequirementDefinition = {
   promptKeys: ['application_management_opt_out_prompt'],
   resolve: (data, config) => {
     const promptData = data['application_management_opt_out_prompt'] as OptOutData
-    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING, response: 'Applicant opted out of the program' }
+    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING }
     return { status: RequirementStatus.NOT_APPLICABLE }
   }
 }

--- a/demos/src/rc/definitions/requirements/operationsInfrastructure.requirements.ts
+++ b/demos/src/rc/definitions/requirements/operationsInfrastructure.requirements.ts
@@ -10,7 +10,7 @@ export const operations_infrastructure_opt_out_req: RequirementDefinition = {
   promptKeys: ['operations_infrastructure_opt_out_prompt'],
   resolve: (data, config) => {
     const promptData = data['operations_infrastructure_opt_out_prompt'] as OptOutData
-    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING, reason: 'Applicant opted out of the program' }
+    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING }
     return { status: RequirementStatus.NOT_APPLICABLE }
   }
 }

--- a/demos/src/rc/definitions/requirements/projectManagement.requirements.ts
+++ b/demos/src/rc/definitions/requirements/projectManagement.requirements.ts
@@ -10,7 +10,7 @@ export const project_management_opt_out_req: RequirementDefinition = {
   promptKeys: ['project_management_opt_out_prompt'],
   resolve: (data, config) => {
     const promptData = data['project_management_opt_out_prompt'] as OptOutData
-    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING, reason: 'Applicant opted out of the program' }
+    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING }
     return { status: RequirementStatus.NOT_APPLICABLE }
   }
 }

--- a/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
+++ b/demos/src/rc/definitions/requirements/softwareDevelopment.requirements.ts
@@ -11,7 +11,7 @@ export const software_dev_opt_out_req: RequirementDefinition = {
   promptKeys: ['software_dev_opt_out_prompt'],
   resolve: (data, config) => {
     const promptData = data['software_dev_opt_out_prompt'] as OptOutData
-    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING, reason: 'Applicant opted out of the program' }
+    if (promptData?.optOut) return { status: RequirementStatus.DISQUALIFYING }
     return { status: RequirementStatus.NOT_APPLICABLE }
   }
 }

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -10,7 +10,7 @@
   import type { FormStore } from '@txstate-mws/svelte-forms'
   import { Button, InlineNotification } from 'carbon-components-svelte'
   import { getContext } from 'svelte'
-  import type { Writable } from 'svelte/store'
+  import { get, type Writable } from 'svelte/store'
   import { goto, invalidate } from '$app/navigation'
   import type { ResolvedPathname } from '$app/types'
   import { uiRegistry } from '../../local/index.js'
@@ -51,10 +51,15 @@
   }
 
   async function onSaved () {
-    await invalidate('request:apply')
-    if (continueAfterSave && prompt.answered) {
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- already resolved      
-      await goto($nextHref.nextHref)
+    if (continueAfterSave) {
+      // Bug issue that became apparent with loaders. 
+      // only refresh nav/answered state, not this prompt page. read the store directly with
+      // get() rather than $nextHref/prompt.answered because its stale until reload reactive updates.
+      await invalidate('request:apply:nav')
+      // eslint-disable-next-line svelte/no-navigation-without-resolve -- already resolved
+      await goto(get(nextHref).nextHref)
+    } else {
+      await invalidate('request:apply')
     }
   }
 

--- a/ui/src/routes/requests/[id]/accept/+layout.ts
+++ b/ui/src/routes/requests/[id]/accept/+layout.ts
@@ -5,6 +5,8 @@ import type { LayoutLoad } from './$types'
 export const load: LayoutLoad = async ({ params, depends }) => {
   const { appRequest, ...applicationInfo } = await api.getAppRequestForExport(params.id)
   depends('request:apply')
+  // separate depend key so the nav/answered state can be refreshed without re-running the prompt page load, which was remounting the current prompt and could flash a skeleton.
+  depends('request:apply:nav')
   if (!appRequest.actions.viewAcceptUI) throw error(404, 'This application cannot be accepted at this time.')
   return { ...applicationInfo, appRequestForExport: { ...appRequest, applications: undefined } }
 }

--- a/ui/src/routes/requests/[id]/apply/+layout.ts
+++ b/ui/src/routes/requests/[id]/apply/+layout.ts
@@ -5,6 +5,8 @@ import type { LayoutLoad } from './$types'
 export const load: LayoutLoad = async ({ params, depends }) => {
   const { appRequest, ...applicationInfo } = await api.getAppRequestForExport(params.id)
   depends('request:apply')
+  // separate depend key so the nav/answered state can be refreshed without re-running the prompt page load, which was remounting the current prompt and could flash a skeleton.
+  depends('request:apply:nav')
   if (!appRequest.actions.viewApplyUI) throw error(404, 'This application cannot be edited at this time.')
   return { ...applicationInfo, appRequestForExport: { ...appRequest, applications: undefined } }
 }


### PR DESCRIPTION
ISSUE

When Continue is clicked on ApplicantPromptPage and triggers onSaved method, invalidate was being called on the entire flow before navigation was triggered. Resulted in prompt.answered being wiped and resulted in user staying on current page. Page was working off stale data

SOLUTION

ApplicantPromptPage onSave + continueAfterSave was updated to use a new invalidation key that is only to accommodate answered and nav updates, but not reload the entire ApplicantPromptPage so decisions weren't based on stale data.