### PR TITLE
Pre-scheduled release:  Correction to prompt navTitle lookup

### DIFF
--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -46,7 +46,7 @@
           routeId: '/requests/[id]/apply/programs'
         }, {
           routeId: '/requests/[id]/apply/[promptId]',
-          title: page => page.data.promptsById?.[page.data.prompt?.id]?.navTitle ?? 'Unknown Prompt'
+          title: page => page.data.promptsById?.[page.params.promptId ?? '']?.navTitle ?? 'Unknown Prompt'
         }]
       }]
     },


### PR DESCRIPTION
ISSUE

routes/Layout.svelte was incorrectly using the page.data.prompt to capture nav title, or set unknown if not found.

SOLUTION

Reference the page.params.promptId in the route to acquire navTitle