### PR TITLE
Reviewer approve page: cap the question column so the answer column k…

### DIFF
--- a/ui/src/internal/components/ReviewerQuestions.svelte
+++ b/ui/src/internal/components/ReviewerQuestions.svelte
@@ -199,7 +199,7 @@
 <style>
   dl.prompts {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: fit-content(50%) minmax(0, 1fr);
     align-items: stretch;
     gap: 0;
     margin: -16px;


### PR DESCRIPTION
…eeps usable width

The prompts grid used `auto 1fr`, which sizes the question column to the max-content width of the longest question title in the section. When one title is long enough to exceed the panel, the answer column collapses to its min-content width and every answer in that section wraps excessively.

Use `fit-content(50%)` so short-title sections still hug their content, but the question column can never take more than half the panel. The answer track gets an explicit `minmax(0, 1fr)` so unbreakable answer content cannot overflow the grid.

Impetus: https://github.com/txstate-etc/va-certification/issues/347