### PR TITLE
Va-cert identified Application Prompt alignment issues, made visible when corrections are required, 

### DIFF
--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -89,7 +89,7 @@
     <h2 id="prompt-title" tabindex="-1" autofocus class="font-bold text-2xl leading-normal text-center">{prompt.title}</h2>
     <p class="text-center"> {prompt.description}</p>
   </div>
-  <Form bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
+  <Form class={def!.applicantPromptPage?.formClass ?? uiRegistry.config.applicantPromptPage?.formClass} bind:store hideFallbackMessage unsavedWarning submit={onSubmit} validate={onValidate} preloadAsDraft={!prompt.hasSavedData} preload={prompt.preloadData} on:saved={onSaved} let:data>
     <svelte:component this={def!.formComponent} {data} appRequestId={appRequestForExport.id} appRequestData={appRequestForExport.data} prestageData={{latest: prompt.prestageData, current: appRequestForExport.data[prompt.key]?.__prestage}} fetched={prompt.fetchedData} configData={prompt.configurationData} gatheredConfigData={prompt.gatheredConfigData}  invalidated={prompt.invalidated} invalidatedReason={prompt.invalidatedReason} />
     <svelte:fragment slot="submit" let:submitting>
       <div class='form-submit flex gap-12 justify-center mt-16'>
@@ -99,20 +99,18 @@
         <Button icon={submitting && !continueAfterSave ? ButtonLoadingIcon : null} type="submit" kind="secondary" disabled={submitting} on:click={() => { continueAfterSave = false }}>Save</Button>
         <Button icon={submitting && !continueAfterSave ? ButtonLoadingIcon : null} type="submit" disabled={submitting} on:click={() => { continueAfterSave = true }}>Continue</Button>
       </div>
-    </svelte:fragment>
-    <div class="flow max-w-screen-md">
+    </svelte:fragment>    
       <!-- Correction inline prompt notification -->
-      {#if prompt.invalidated && !$store?.hasUnsavedChanges}
-        <InlineNotification
-          kind="warning-alt"
-          title='Corrections needed:'
-          hideCloseButton={true}
-          lowContrast
-          subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}
-        />
-      {/if}
-    </div>
-  </Form>
-  
+    {#if prompt.invalidated && !$store?.hasUnsavedChanges}
+      <InlineNotification
+        class={def!.applicantPromptPage?.invalidatedInlineNotificationClass ?? uiRegistry.config.applicantPromptPage?.invalidatedInlineNotificationClass}
+        kind="warning-alt"
+        title='Review needed'
+        hideCloseButton={true}
+        lowContrast
+        subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}
+      />
+    {/if}    
+  </Form>  
 {/key}
 

--- a/ui/src/internal/components/ApplicantPromptPage.svelte
+++ b/ui/src/internal/components/ApplicantPromptPage.svelte
@@ -105,7 +105,7 @@
       <InlineNotification
         class={def!.applicantPromptPage?.invalidatedInlineNotificationClass ?? uiRegistry.config.applicantPromptPage?.invalidatedInlineNotificationClass}
         kind="warning-alt"
-        title='Review needed'
+        title='Corrections needed'
         hideCloseButton={true}
         lowContrast
         subtitle={prompt.invalidatedReason ?? 'Must update form data before continuing'}

--- a/ui/src/lib/registry.ts
+++ b/ui/src/lib/registry.ts
@@ -113,6 +113,30 @@ export interface PromptDefinition {
    * A boolean value will result in a default skeleton loader. 
    */
   loader?: Loader
+
+  /**
+   * This is the same applicantPromptPage CSS configurations that exist at the UIConfig (global applicant page prompt) level.  Used in a situation where a specific prompt
+   * requires a specific layout that doesn't match default.  This will override global configuration
+   */
+  applicantPromptPage? : ApplicantPromptPageDefinition
+}
+
+/**
+ * Applicant prompts are wrapped by the default CL Form component, so any styling applied within the svelte prompt
+ * is independent (does not influence) of the layout of form elements that exist as part of the CL Form (eg. Validation notices).
+ * This can result in inconsistencies in desired layouts as CL Form elements are default left aligned while prompts could expect/desire
+ * center alignment.  This property allows the developer to set the global prompt page Form CSS class variable.  This can be overwritten at the
+ * individual prompt level if specific prompts desire specific layouts.  This definition is used for defining those elements if required
+ */
+export interface ApplicantPromptPageDefinition {
+  /**
+   * CSS class settings specific to the Form component that wraps the prompt
+   */
+  formClass?: string,        
+  /**
+   * CSS class settings specific to the corrections inline notification within the Form
+   */
+  invalidatedInlineNotificationClass?: string
 }
 
 export interface Terminologies {
@@ -168,6 +192,15 @@ export interface UIConfig {
    * Defaults to 30 if not specified.
    */
   applicantDashboardRecentDays?: number
+
+  /**
+ * Applicant prompts are wrapped by the default CL Form component, so any styling applied within the svelte prompt
+ * is independent (does not influence) of the layout of form elements that exist as part of the CL Form (eg. Validation notices).
+ * This can result in inconsistencies in desired layouts as CL Form elements are default left aligned while prompts could expect/desire
+ * center alignment.  This property allows the developer to set the global prompt page Form CSS class variable.  This can be overwritten at the
+ * individual prompt level if specific prompts desire specific layouts
+ */
+  applicantPromptPage? : ApplicantPromptPageDefinition
 
   /**
    * Applicant Review submission page title and subtitle text.

--- a/ui/src/local/index.ts
+++ b/ui/src/local/index.ts
@@ -178,13 +178,14 @@ import { api } from '$internal/api'
 import ApplicantPromptSkeleton from '$internal/components/ApplicantPromptSkeleton.svelte'
 import { GeneralTextSkeleton } from '@txstate-mws/carbon-svelte'
 
-const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, applicantReview, programs, requirements, prompts, userLookup, slots } = configureDemoInstanceParams()
+const { appName, applicantDashboardIntroHeader, applicantDashboardIntroDetail, applicantDashboardRecentDays, applicantPromptPage, applicantReview, programs, requirements, prompts, userLookup, slots } = configureDemoInstanceParams()
 
 export const uiRegistry = new UIRegistry({
   appName,
   applicantDashboardIntroHeader,
   applicantDashboardIntroDetail,
   applicantDashboardRecentDays,
+  applicantPromptPage,
   applicantReview,
   programs,
   requirements,
@@ -422,6 +423,10 @@ function configureDemoInstanceParams (): UIConfig {
       appName: 'MWS Technical Mentorship Experience',
       applicantDashboardIntroHeader: 'Apply for a technical mentorship here!',
       applicantDashboardIntroDetail: 'After applying for a mentorship, eligibilty will be determined based on your responses',
+      applicantPromptPage: {
+        formClass: 'max-w-[800px] mx-auto',
+        invalidatedInlineNotificationClass: 'w-full mx-auto'
+      },
       applicantReview: {
         title: 'Review your technical mentorship application',
         subTitle: 'Confirm the technical mentorship benefits shown are the ones you are requesting and that your responses are correct, or make changes before submitting.'
@@ -511,7 +516,10 @@ function configureDemoInstanceParams (): UIConfig {
       {
         key: 'outside_class_example_prompt',
         formComponent: OutsideClassExample,
-        displayComponent: OutsideClassExampleDisplay
+        displayComponent: OutsideClassExampleDisplay,
+        applicantPromptPage: {
+          formClass: 'max-w-[500px] mx-auto'
+        }
       },
       {
         key: 'assess_outside_class_example_prompt',
@@ -521,7 +529,10 @@ function configureDemoInstanceParams (): UIConfig {
       {
         key: 'critical_thinking_prompt',
         formComponent: CriticalThinking,
-        displayComponent: CriticalThinkingDisplay
+        displayComponent: CriticalThinkingDisplay,
+        applicantPromptPage: {
+          invalidatedInlineNotificationClass: 'max-w-[400px] mx-auto'
+        }
       },
       {
         key: 'assess_critical_thinking_prompt',


### PR DESCRIPTION
https://github.com/txstate-etc/va-certification/issues/345

ISSUE

The ApplicantPromptPage, and it's loading of a dynamic prompt svelte component, is wrapped under a Form component.  Currently any alignment or styling that can be updated within the prompt does not bubble up to the Form and it's elements (validation, corrections).  Makes sense, CSS doesn't carry up.  Designer expectation though is that if all prompt elements are centered, then all form elements should match, but right now there is no means to execute.

SOLUTION

UIRegistry configuration, and prompt definition, have been updated to include an optional `applicantPromptPage` property that allows down stream devs to modify CSS styling/layout for the applicantPromptPage Form, to keep all elements aligned.  Per prompt definitions trump the global UIRegistry configuration to support custom alignments for certain prompt pages if needed.  