### PR TITLE
Restrict width of applicant dashboard cards to 680px

### DIFF
--- a/ui/src/routes/dashboards/applicant/+page.svelte
+++ b/ui/src/routes/dashboards/applicant/+page.svelte
@@ -413,11 +413,13 @@
     {:else}
       <CardGrid cardSize="500px">
         {#each appRequests as request (request.id)}
-          <AppRequestCard
-            {request}
-            actions={buildCardActions(request)}
-            showAcceptanceButtons={true}
-          />
+          <div class="max-w-[680px]">
+            <AppRequestCard
+              {request}
+              actions={buildCardActions(request)}
+              showAcceptanceButtons={true}
+            />
+          </div>
         {/each}
       </CardGrid>
     {/if}


### PR DESCRIPTION
https://github.com/txstate-etc/va-certification/issues/330

ISSUE

An applicant dashboard cards main action button moves into the three dot vertical menu, at certain view widths, which makes understanding next action difficult for the user.

SOLUTION

Force max width of Cards to 680px using a wrapper div